### PR TITLE
Centralize build range handling and enable linting

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,4 @@
 fail_on_violations: true
 
+ruby:
+  config_file: .rubocop.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+fail_on_violations: true
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+# Don't allow more complexity than we have, but don't really enforce it either
+Metrics/AbcSize:
+  Max: 121
+
+Metrics/BlockLength:
+  Max: 34
+
+Metrics/CyclomaticComplexity:
+  Max: 19
+
+Metrics/MethodLength:
+  Max: 105
+
+Metrics/PerceivedComplexity:
+  Max: 20

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem 'groupdate'
 gem 'launchy'
 gem 'memoist'
 gem 'parallel'
+gem 'rubocop', require: false
 gem 'ruby-progressbar'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gem 'activesupport'
 gem 'groupdate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    ast (2.3.0)
     concurrent-ruby (1.0.4)
     groupdate (3.2.0)
       activesupport (>= 3)
@@ -17,11 +18,22 @@ GEM
     memoist (0.14.0)
     minitest (5.10.1)
     parallel (1.9.0)
+    parser (2.3.3.1)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     public_suffix (2.0.4)
+    rainbow (2.2.1)
+    rubocop (0.46.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (1.1.2)
 
 PLATFORMS
   ruby
@@ -32,6 +44,7 @@ DEPENDENCIES
   launchy
   memoist
   parallel
+  rubocop
   ruby-progressbar
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ repository: code-dot-org/code-dot-org
 ## Common Options
 
 ### Specifying build ranges
-All of the tools accept `--start [build-number]` and `--end [build-number]` options that let you specify a build range you'd like to operate on.
+All of the tools accept `--after [build-number]`, `--before [build-number]` and `--count [build-count]` options that let you specify a build range you'd like to operate on.
 
-* If both `--start` and `--end` are supplied, the tool will use all builds in that range (inclusive).
-* If only `--start` is given, the tool will use all builds from that build up to the most recent build.
-* If no range is supplied, the tool will use the 30 most recent builds.
+* If both `--after` and `--before` are supplied, the tool will use all builds in that range (inclusive).
+* If only `--after` is given, the tool will use all builds from that build up to the most recent build.
+* If `--count` is supplied with either `--after` or `--before` you'll get `count` builds after/before the given build.
+* If only `--count` is supplied you'll get the `count` latest builds.
 
 ### Limiting results to one branch
 Most tools accept a `--branch [branch-name]` option that will further limit the selected build range, only including builds on the given branch.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ From the repository root, run `bundle install`.  Then you should be able to exec
 
 The tools will write to `~/.circlarify` to cache build information and avoid redundant requests to the Circle CI API.  Cached build JSON gets compressed; caching summary data for 10,000 builds requires about 115MB of disk space.
 
+### config.yml
+You can optionally create a configuration file at `~/.circlarify/config.yml` to provide some default parameters to all commands.
+
+```yml
+# config.yml
+
+# Default repository to use when searching builds
+repository: code-dot-org/code-dot-org
+```
+
 ## Common Options
 
 ### Specifying build ranges

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -8,7 +8,7 @@ require 'optparse'
 require_relative './lib/config'
 require_relative './lib/circle_project'
 
-config = Config.new
+config = Circlarify::Config.new
 
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -26,31 +26,6 @@ options = {
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./compute-failure-rates [options]'
 
-  opts.separator <<-EXAMPLES
-
-  Examples:
-
-    Default behavior, view stats for the last 30 builds:
-    ./compute-failure-rates
-
-    View stats for 30 builds ending at build 123:
-    ./compute-failure-rates --end 123
-
-    View stats for all builds since (and including) build 123:
-    ./compute-failure-rates --start 123
-
-    View stats for builds in range 123-456 inclusive:
-    ./compute-failure-rates --start 123 --end 456
-
-  Options:
-  EXAMPLES
-
-  opts.on('--start StartBuildNumber', String, 'Start searching at build #. Default: Get 30 builds.') do |n|
-    options[:start_build] = n.to_i
-  end
-  opts.on('--end EndBuildNumber', String, 'End searching at build #. Default: Latest build.') do |n|
-    options[:end_build] = n.to_i
-  end
   opts.on('--group branchName,branchName', Array, 'Add a column aggregating results for the listed branches.') do |a|
     options[:custom_columns] << a
   end
@@ -69,13 +44,13 @@ end.parse!
 
 begin
   @project = CircleProject.new(project.repository)
+  build_range = project.build_range
 rescue ArgumentError => e
   puts e.message
   exit(-1)
 end
 
 # Download and format the build information we need
-build_range = @project.build_range_from_options(options)
 build_infos = @project.get_builds(build_range).map do |build|
   next if build['queued_at'].nil? || build['branch'].nil? || build['outcome'].nil?
   {

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -5,10 +5,10 @@
 require 'active_support/time'
 require 'launchy'
 require 'optparse'
-require_relative './lib/config'
+require_relative './lib/project'
 require_relative './lib/circle_project'
 
-config = Circlarify::Config.new
+project = Circlarify::Project.new
 
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
@@ -64,11 +64,11 @@ OptionParser.new do |opts|
     options[:output_format] = :plot
   end
 
-  config.add_to_cli_options opts
+  project.provide_cli_options opts
 end.parse!
 
 begin
-  @project = CircleProject.new(config.repository)
+  @project = CircleProject.new(project.repository)
 rescue ArgumentError => e
   puts e.message
   exit(-1)

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -43,8 +43,6 @@ end.parse!
 
 build_infos = []
 begin
-  build_range = project.build_range
-
   # Download and format the build information we need
   build_infos = project.builds.map do |build|
     next if build['queued_at'].nil? || build['branch'].nil? || build['outcome'].nil?
@@ -104,7 +102,7 @@ stats_by_date = builds_by_date.hmap do |date, build_infos_for_date|
 end
 
 # Print build stats
-puts "Failure rates for builds #{build_range} by date (1.0 = 100% failures)"
+puts "Failure rates for builds #{project.build_range} by date (1.0 = 100% failures)"
 if options[:output_format] == 'csv'
   puts format("%s#{',%s' * columns.size}", 'Date', *columns.keys)
   stats_by_date.each do |date, stats|
@@ -151,7 +149,7 @@ elsif options[:output_format] == :plot
   end
   js_data += "]\n"
 
-  title = "Circle CI #{options[:branch]} builds by outcome for #{dates.min.strftime('%Y-%m-%d')}..#{dates.max.strftime('%Y-%m-%d')} (builds #{build_range})"
+  title = "Circle CI #{options[:branch]} builds by outcome for #{dates.min.strftime('%Y-%m-%d')}..#{dates.max.strftime('%Y-%m-%d')} (builds #{project.build_range})"
 
   # Write out plot
   # https://developers.google.com/chart/interactive/docs/gallery/areachart

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -137,7 +137,7 @@ elsif options[:output_format] == :plot
   # Display a graph of failure rates over time
   #
 
-  throw Error.new('Must provide a --branch to plot') if options[:branch].nil?
+  raise Exception.new('Must provide a --branch to plot') if options[:branch].nil?
 
   # Make sure weekends are included, and show up as zero
   dates = stats_by_date.keys.map{|d| DateTime.strptime("#{d} -8", '%Y-%m-%d %z')}

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -6,7 +6,6 @@ require 'active_support/time'
 require 'launchy'
 require 'optparse'
 require_relative './lib/project'
-require_relative './lib/circle_project'
 
 project = Circlarify::Project.new
 
@@ -42,25 +41,25 @@ OptionParser.new do |opts|
   project.provide_cli_options opts
 end.parse!
 
+build_infos = []
 begin
-  @project = CircleProject.new(project.repository)
   build_range = project.build_range
+
+  # Download and format the build information we need
+  build_infos = project.builds.map do |build|
+    next if build['queued_at'].nil? || build['branch'].nil? || build['outcome'].nil?
+    {
+      build_num: build['build_num'],
+      queued_at: DateTime.parse(build['queued_at']),
+      branch: build['branch'],
+      # Possible build outcomes: :canceled, :infrastructure_fail, :timedout, :failed, :no_tests or :success
+      succeeded: build['outcome'] == 'success',
+      failed: build['outcome'] == 'failed' || build['outcome'] == 'timedout'
+    }
+  end
 rescue ArgumentError => e
   puts e.message
   exit(-1)
-end
-
-# Download and format the build information we need
-build_infos = @project.get_builds(build_range).map do |build|
-  next if build['queued_at'].nil? || build['branch'].nil? || build['outcome'].nil?
-  {
-    build_num: build['build_num'],
-    queued_at: DateTime.parse(build['queued_at']),
-    branch: build['branch'],
-    # Possible build outcomes: :canceled, :infrastructure_fail, :timedout, :failed, :no_tests or :success
-    succeeded: build['outcome'] == 'success',
-    failed: build['outcome'] == 'failed' || build['outcome'] == 'timedout'
-  }
 end
 
 # Group the builds by date

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -9,10 +9,11 @@ require_relative './lib/project'
 
 project = Circlarify::Project.new
 
+# Augment Hash with hmap function
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
-  def hmap(&block)
-    Hash[map {|k, v| yield k, v }]
+  def hmap(&_)
+    Hash[map { |k, v| yield k, v }]
   end
 end
 
@@ -25,10 +26,14 @@ options = {
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./compute-failure-rates [options]'
 
-  opts.on('--group branchName,branchName', Array, 'Add a column aggregating results for the listed branches.') do |a|
+  opts.on('--group branchName,branchName',
+          Array,
+          'Add a column aggregating results for the listed branches.') do |a|
     options[:custom_columns] << a
   end
-  opts.on('--branch branchName', String, 'ONLY show results for the given branch.') do |b|
+  opts.on('--branch branchName',
+          String,
+          'ONLY show results for the given branch.') do |b|
     options[:branch] = b
   end
   opts.on('--csv', 'Display results in CSV format.') do
@@ -61,22 +66,33 @@ end
 
 # Group the builds by date
 builds_by_date = build_infos.compact.group_by do |build_info|
-  build_info[:queued_at].to_time.in_time_zone('Pacific Time (US & Canada)').strftime('%Y-%m-%d')
+  build_info[:queued_at]
+    .to_time
+    .in_time_zone('Pacific Time (US & Canada)')
+    .strftime('%Y-%m-%d')
 end
 
 # Define columns - each maps to a lambda that filters builds
 columns = {
-  'Total' => ->(builds) {builds},
-  'Pipeline' => ->(builds) {builds.select {|i| %w(staging test production).include?(i[:branch])}},
-  'Branch' => ->(builds) {builds.reject {|i| %w(staging test production).include?(i[:branch])}}
+  'Total' => ->(builds) { builds },
+  'Pipeline' => lambda do |builds|
+    builds.select { |i| %w(staging test production).include?(i[:branch]) }
+  end,
+  'Branch' => lambda do |builds|
+    builds.reject { |i| %w(staging test production).include?(i[:branch]) }
+  end
 }
 options[:custom_columns].each do |branches|
-  columns[branches.join(',')] = ->(builds) {builds.select{|i| branches.include?(i[:branch])}}
+  columns[branches.join(',')] = lambda do |builds|
+    builds.select { |i| branches.include?(i[:branch]) }
+  end
 end
 # Or only show one branch if we passed the branch option
 unless options[:branch].nil?
   columns = {
-      options[:branch] => ->(builds) {builds.select {|i| i[:branch] == options[:branch]}}
+    options[:branch] => lambda do |builds|
+      builds.select { |i| i[:branch] == options[:branch] }
+    end
   }
 end
 
@@ -86,14 +102,14 @@ stats_by_date = builds_by_date.hmap do |date, build_infos_for_date|
     date,
     columns.hmap do |name, column|
       builds = column.call build_infos_for_date
-      succeeded_builds = builds.select {|i| i[:succeeded]}.count
-      failed_builds = builds.select {|i| i[:failed]}.count
+      succeeded_builds = builds.select { |i| i[:succeeded] }.count
+      failed_builds = builds.select { |i| i[:failed] }.count
       [
         name,
         {
           total_builds: succeeded_builds + failed_builds,
           failed_builds: failed_builds,
-          failure_rate: Float(failed_builds) / (succeeded_builds + failed_builds)
+          failure_rate: failed_builds.to_f / (succeeded_builds + failed_builds)
         }
       ]
     end
@@ -101,11 +117,13 @@ stats_by_date = builds_by_date.hmap do |date, build_infos_for_date|
 end
 
 # Print build stats
-puts "Failure rates for builds #{project.build_range} by date (1.0 = 100% failures)"
+puts "Failure rates for builds #{project.build_range} by date "\
+  '(1.0 = 100% failures)'
 if options[:output_format] == 'csv'
   puts format("%s#{',%s' * columns.size}", 'Date', *columns.keys)
   stats_by_date.each do |date, stats|
-    puts format("%s#{',%.3f' * columns.size}", date, *stats.map {|_, v| v[:failure_rate].round(3)})
+    row_of_stats = stats.map { |_, v| v[:failure_rate].round(3) }
+    puts format("%s#{',%.3f' * columns.size}", date, *row_of_stats)
   end
 
 elsif options[:output_format] == :plot
@@ -114,24 +132,26 @@ elsif options[:output_format] == :plot
   # Display a graph of failure rates over time
   #
 
-  raise Exception.new('Must provide a --branch to plot') if options[:branch].nil?
+  raise Exception, 'Must provide a --branch to plot' if options[:branch].nil?
 
   # Make sure weekends are included, and show up as zero
-  dates = stats_by_date.keys.map{|d| DateTime.strptime("#{d} -8", '%Y-%m-%d %z')}
+  dates = stats_by_date.keys.map do |d|
+    DateTime.strptime("#{d} -8", '%Y-%m-%d %z')
+  end
   ordered_stats = []
   (dates.min..dates.max).each do |date|
-    if date.wday == 0 || date.wday == 6
+    if [0, 6].include? date.wday
       ordered_stats << {
-          date: date,
-          total_builds: 0,
-          failed_builds: 0
+        date: date,
+        total_builds: 0,
+        failed_builds: 0
       }
     else
       branch_stats = stats_by_date[date.strftime('%Y-%m-%d')][options[:branch]]
       ordered_stats << {
-          date: date,
-          total_builds: branch_stats[:total_builds],
-          failed_builds: branch_stats[:failed_builds]
+        date: date,
+        total_builds: branch_stats[:total_builds],
+        failed_builds: branch_stats[:failed_builds]
       }
     end
   end
@@ -148,7 +168,9 @@ elsif options[:output_format] == :plot
   end
   js_data += "]\n"
 
-  title = "Circle CI #{options[:branch]} builds by outcome for #{dates.min.strftime('%Y-%m-%d')}..#{dates.max.strftime('%Y-%m-%d')} (builds #{project.build_range})"
+  title = "Circle CI #{options[:branch]} builds by outcome for "\
+    "#{dates.min.strftime('%Y-%m-%d')}..#{dates.max.strftime('%Y-%m-%d')} "\
+    "(builds #{project.build_range})"
 
   # Write out plot
   # https://developers.google.com/chart/interactive/docs/gallery/areachart
@@ -188,12 +210,19 @@ elsif options[:output_format] == :plot
 
 else
 
-  puts format("%-10s#{' %16s' * columns.size}", 'Date', *columns.keys.map {|k| k[0, 14]})
+  column_names = columns.keys.map { |k| k[0, 14] }
+  puts format("%-10s#{' %16s' * columns.size}", 'Date', *column_names)
   stats_by_date.each do |date, stats|
+    row_of_stats = stats.map do |_, v|
+      [
+        format('%s/%s', v[:failed_builds], v[:total_builds]),
+        v[:failure_rate].round(3)
+      ]
+    end.flatten
     puts format(
       "%-10s#{'  %7s = %5.3f' * columns.size}",
       date,
-      *stats.map {|_, v| [format("%s/%s", v[:failed_builds], v[:total_builds]), v[:failure_rate].round(3)]}.flatten
+      *row_of_stats
     )
   end
 end

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -45,14 +45,13 @@ build_infos = []
 begin
   # Download and format the build information we need
   build_infos = project.builds.map do |build|
-    next if build['queued_at'].nil? || build['branch'].nil? || build['outcome'].nil?
+    next if build.queued_at.nil? || build.branch.nil? || build.outcome.nil?
     {
-      build_num: build['build_num'],
-      queued_at: DateTime.parse(build['queued_at']),
-      branch: build['branch'],
-      # Possible build outcomes: :canceled, :infrastructure_fail, :timedout, :failed, :no_tests or :success
-      succeeded: build['outcome'] == 'success',
-      failed: build['outcome'] == 'failed' || build['outcome'] == 'timedout'
+      build_num: build.build_num,
+      queued_at: build.queued_at,
+      branch: build.branch,
+      succeeded: build.succeeded?,
+      failed: build.failed?
     }
   end
 rescue ArgumentError => e

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -68,7 +68,7 @@ OptionParser.new do |opts|
     exit
   end
 
-  config.add_to_cli_options(opts)
+  config.add_to_cli_options opts
 end.parse!
 
 begin

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -5,7 +5,10 @@
 require 'active_support/time'
 require 'launchy'
 require 'optparse'
+require_relative './lib/config'
 require_relative './lib/circle_project'
+
+config = Config.new
 
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
@@ -64,9 +67,16 @@ OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  config.add_to_cli_options(opts)
 end.parse!
 
-@project = CircleProject.new('code-dot-org/code-dot-org')
+begin
+  @project = CircleProject.new(config.repository)
+rescue ArgumentError => e
+  puts e.message
+  exit(-1)
+end
 
 # Download and format the build information we need
 build_range = @project.build_range_from_options(options)

--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -63,10 +63,6 @@ OptionParser.new do |opts|
   opts.on('--plot', 'Display results as a graph') do
     options[:output_format] = :plot
   end
-  opts.on_tail('-h', '--help', 'Show this message.') do
-    puts opts
-    exit
-  end
 
   config.add_to_cli_options opts
 end.parse!

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -11,7 +11,7 @@ require_relative './lib/circle_project'
 
 OUTPUT_DIRECTORY = File.expand_path('~/.circle-cli/output').freeze
 
-config = Config.new
+config = Circlarify::Config.new
 
 def main(options)
 

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -11,7 +11,6 @@ require_relative './lib/project'
 OUTPUT_DIRECTORY = File.expand_path('~/.circle-cli/output').freeze
 
 def main(project, options)
-
   # Download and format the information we need
   if options[:output_format] == :plot
     builds = []
@@ -23,9 +22,11 @@ def main(project, options)
 
       build_steps = {}
       build.steps.each do |step|
-        next unless options[:step_pattern].nil? || options[:step_pattern] =~ step['name']
+        next unless options[:step_pattern].nil? ||
+                    options[:step_pattern] =~ step['name']
         step['actions'].each do |action|
-          next unless options[:container_num] == action['index'] || step['actions'].size == 1
+          next unless options[:container_num] == action['index'] ||
+                      step['actions'].size == 1
           step_name = step['name']
           step_duration_seconds = action['run_time_millis'] / 1000
           step_times[step_name] ||= []
@@ -34,24 +35,27 @@ def main(project, options)
         end
       end
 
-      builds.push({
+      builds.push(
         time: build.start_time,
         steps: build_steps
-      })
+      )
     end
 
     # Compute and sort average step times
-    average_step_times = step_times.
-        map{|key, times| [key, mean(times)]}.
-        sort{|a, b| b[1] <=> a[1]}
+    average_step_times = step_times
+                         .map { |key, times| [key, mean(times)] }
+                         .sort { |a, b| b[1] <=> a[1] }
 
     js_data = "[\n"
-    js_data += "['Date', #{average_step_times.map{|k| JSON.generate(k[0])}.join(', ')}],\n"
+    column_names = average_step_times.map { |k| JSON.generate(k[0]) }
+    js_data += "['Date', #{column_names.join(', ')}],\n"
     builds.each do |build|
       # Represent date as a JS date, constructed with ms since the epoch
       js_build_time = "new Date(#{build[:time].to_f * 1000})"
       # Divide ms step durations by 1000, fill missing durations with zero
-      js_step_durations = average_step_times.map{|k| build[:steps][k[0]].nil? ? 0 : build[:steps][k[0]]}
+      js_step_durations = average_step_times.map do |k|
+        build[:steps][k[0]].nil? ? 0 : build[:steps][k[0]]
+      end
 
       js_data += "[#{js_build_time}, #{js_step_durations.join(', ')}],\n"
     end
@@ -110,9 +114,10 @@ def main(project, options)
       build_durations.push(build.build_time_millis)
 
       build.steps.each do |step|
-        next unless options[:step_pattern].nil? || options[:step_pattern] =~ step['name']
+        next unless options[:step_pattern].nil? ||
+                    options[:step_pattern] =~ step['name']
         step['actions'].each do |action|
-          step_key = format("%9d %s", action['index'], step['name'])
+          step_key = format('%9d %s', action['index'], step['name'])
           step_durations[step_key] ||= []
           step_durations[step_key].push(action['run_time_millis'])
         end
@@ -120,17 +125,18 @@ def main(project, options)
     end
 
     # Write out averages
-    puts "Limited to branch: #{options[:branch_name]}" unless options[:branch_name].nil?
-    puts "Average build time for #{build_durations.size} successful builds in range #{project.build_range}"
-    puts ms_to_readable_duration(build_durations.inject(:+).to_f / build_durations.size)
+    puts "Limited to branch: #{options[:branch_name]}" if options[:branch_name]
+    puts "Average build time for #{build_durations.size} "\
+      "successful builds in range #{project.build_range}"
+    puts ms_to_readable_duration(mean(build_durations))
 
     puts "\nAverage build times for steps"
-    puts format("%8s %9s %s", 'Duration', 'Container', 'Name')
-    step_durations.
-      map{|key, durations| [key, durations.inject(:+).to_f / durations.size]}.
-      sort{|a, b| b[1] <=> a[1]}.
-      each do |step|
-        puts format("%s %s", ms_to_readable_duration(step[1]), step[0])
+    puts format('%8s %9s %s', 'Duration', 'Container', 'Name')
+    step_durations
+      .map { |key, durations| [key, mean(durations)] }
+      .sort { |a, b| b[1] <=> a[1] }
+      .each do |step|
+        puts format('%s %s', ms_to_readable_duration(step[1]), step[0])
       end
   end
 rescue ArgumentError => e
@@ -144,9 +150,10 @@ end
 #   5,369,000 -> ' 1:29:29'
 #     272,000 -> '    4:32'
 def ms_to_readable_duration(ms)
-  Time.at(ms/1000).utc.
-      strftime("%k:%M:%S").
-      gsub(/^ 0:0?/) {|match| ' ' * match.size}
+  Time.at(ms / 1000)
+      .utc
+      .strftime('%k:%M:%S')
+      .gsub(/^ 0:0?/) { |match| ' ' * match.size }
 end
 
 # Get the average of the values in an array
@@ -163,14 +170,18 @@ options = {
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./compute-timing-stats [options]'
 
-  opts.on('--branch BranchName', String, 'Limit results to builds for one branch.') do |branch_name|
+  opts.on('--branch BranchName',
+          String,
+          'Limit results to builds for one branch.') do |branch_name|
     options[:branch_name] = branch_name
   end
-  opts.on('--step StepPattern', 'Filter results to steps matching given pattern.') do |step_pattern|
+  opts.on('--step StepPattern',
+          'Filter results to steps matching given pattern.') do |step_pattern|
     options[:step_pattern] = Regexp.new(step_pattern, Regexp::IGNORECASE)
   end
-  opts.on('--container ContainerNum', 'Show results from a different container (default 0).') do |container_num|
-    options[:container_num] = container_num.to_i
+  opts.on('--container ContainerNum',
+          'Show results from a different container (default 0).') do |num|
+    options[:container_num] = num.to_i
   end
   opts.on('--plot', 'Display results as a graph.') do
     options[:output_format] = :plot

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -6,18 +6,18 @@ require 'launchy'
 require 'optparse'
 require 'time'
 require 'pp'
-require_relative './lib/config'
+require_relative './lib/project'
 require_relative './lib/circle_project'
 
 OUTPUT_DIRECTORY = File.expand_path('~/.circle-cli/output').freeze
 
-config = Circlarify::Config.new
+project = Circlarify::Project.new
 
 def main(options)
 
   # Download and format the information we need
   begin
-    @project = CircleProject.new(config.repository)
+    @project = CircleProject.new(project.repository)
   rescue ArgumentError => e
     puts e.message
     exit(-1)
@@ -208,7 +208,7 @@ OptionParser.new do |opts|
     options[:output_format] = :plot
   end
 
-  config.add_to_cli_options opts
+  project.provide_cli_options opts
 end.parse!
 
 main(options)

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -163,31 +163,6 @@ options = {
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./compute-timing-stats [options]'
 
-  opts.separator <<-EXAMPLES
-
-  Examples:
-
-    Default behavior, view stats for the last 30 builds:
-    ./compute-timing-stats
-
-    View stats for 30 builds ending at build 123:
-    ./compute-timing-stats --end 123
-
-    View stats for all builds since (and including) build 123:
-    ./compute-timing-stats --start 123
-
-    View stats for builds in range 123-456 inclusive:
-    ./compute-timing-stats --start 123 --end 456
-
-  Options:
-  EXAMPLES
-
-  opts.on('--start StartBuildNumber', String, 'Start searching at build #. Default: Get 30 builds.') do |n|
-    options[:start_build] = n.to_i
-  end
-  opts.on('--end EndBuildNumber', String, 'End searching at build #. Default: Latest build.') do |n|
-    options[:end_build] = n.to_i
-  end
   opts.on('--branch BranchName', String, 'Limit results to builds for one branch.') do |branch_name|
     options[:branch_name] = branch_name
   end

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -6,14 +6,17 @@ require 'launchy'
 require 'optparse'
 require 'time'
 require 'pp'
+require_relative './lib/config'
 require_relative './lib/circle_project'
 
 OUTPUT_DIRECTORY = File.expand_path('~/.circle-cli/output').freeze
 
+config = Config.new
+
 def main(options)
 
   # Download and format the information we need
-  @project = CircleProject.new('code-dot-org/code-dot-org')
+  @project = CircleProject.new(config.repository)
   build_range = @project.build_range_from_options(options)
 
   if options[:output_format] == :plot
@@ -203,6 +206,8 @@ OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  config.add_to_cli_options opts
 end.parse!
 
 main(options)

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -202,10 +202,6 @@ OptionParser.new do |opts|
   opts.on('--plot', 'Display results as a graph.') do
     options[:output_format] = :plot
   end
-  opts.on_tail('-h', '--help', 'Show this message.') do
-    puts opts
-    exit
-  end
 
   config.add_to_cli_options opts
 end.parse!

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -17,12 +17,12 @@ def main(project, options)
     builds = []
     step_times = {}
     project.builds(true).each do |build|
-      next if build['outcome'] != 'success'
-      next if build['steps'].nil? || build['build_time_millis'].nil?
-      next unless options[:branch_name].nil? || build['branch'] == options[:branch_name]
+      next unless build.succeeded?
+      next if build.steps.nil? || build.build_time_millis.nil?
+      next unless build.branch? options[:branch_name]
 
       build_steps = {}
-      build['steps'].each do |step|
+      build.steps.each do |step|
         next unless options[:step_pattern].nil? || options[:step_pattern] =~ step['name']
         step['actions'].each do |action|
           next unless options[:container_num] == action['index'] || step['actions'].size == 1
@@ -35,7 +35,7 @@ def main(project, options)
       end
 
       builds.push({
-        time: Time.parse(build['start_time']),
+        time: build.start_time,
         steps: build_steps
       })
     end
@@ -103,13 +103,13 @@ def main(project, options)
     step_durations = {}
 
     project.builds(true).each do |build|
-      next if build['outcome'] != 'success'
-      next if build['steps'].nil? || build['build_time_millis'].nil?
-      next unless options[:branch_name].nil? || build['branch'] == options[:branch_name]
+      next unless build.succeeded?
+      next if build.steps.nil? || build.build_time_millis.nil?
+      next unless build.branch? options[:branch_name]
 
-      build_durations.push(build['build_time_millis'])
+      build_durations.push(build.build_time_millis)
 
-      build['steps'].each do |step|
+      build.steps.each do |step|
         next unless options[:step_pattern].nil? || options[:step_pattern] =~ step['name']
         step['actions'].each do |action|
           step_key = format("%9d %s", action['index'], step['name'])

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -18,11 +18,11 @@ def main(options)
   # Download and format the information we need
   begin
     @project = CircleProject.new(project.repository)
+    build_range = project.build_range
   rescue ArgumentError => e
     puts e.message
     exit(-1)
   end
-  build_range = @project.build_range_from_options(options)
 
   if options[:output_format] == :plot
     builds = []

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -16,7 +16,12 @@ config = Circlarify::Config.new
 def main(options)
 
   # Download and format the information we need
-  @project = CircleProject.new(config.repository)
+  begin
+    @project = CircleProject.new(config.repository)
+  rescue ArgumentError => e
+    puts e.message
+    exit(-1)
+  end
   build_range = @project.build_range_from_options(options)
 
   if options[:output_format] == :plot

--- a/compute-timing-stats
+++ b/compute-timing-stats
@@ -7,27 +7,16 @@ require 'optparse'
 require 'time'
 require 'pp'
 require_relative './lib/project'
-require_relative './lib/circle_project'
 
 OUTPUT_DIRECTORY = File.expand_path('~/.circle-cli/output').freeze
 
-project = Circlarify::Project.new
-
-def main(options)
+def main(project, options)
 
   # Download and format the information we need
-  begin
-    @project = CircleProject.new(project.repository)
-    build_range = project.build_range
-  rescue ArgumentError => e
-    puts e.message
-    exit(-1)
-  end
-
   if options[:output_format] == :plot
     builds = []
     step_times = {}
-    @project.get_builds(build_range, true).each do |build|
+    project.builds(true).each do |build|
       next if build['outcome'] != 'success'
       next if build['steps'].nil? || build['build_time_millis'].nil?
       next unless options[:branch_name].nil? || build['branch'] == options[:branch_name]
@@ -113,7 +102,7 @@ def main(options)
     # Map of step key to a list of run times
     step_durations = {}
 
-    @project.get_builds(build_range, true).each do |build|
+    project.builds(true).each do |build|
       next if build['outcome'] != 'success'
       next if build['steps'].nil? || build['build_time_millis'].nil?
       next unless options[:branch_name].nil? || build['branch'] == options[:branch_name]
@@ -132,7 +121,7 @@ def main(options)
 
     # Write out averages
     puts "Limited to branch: #{options[:branch_name]}" unless options[:branch_name].nil?
-    puts "Average build time for #{build_durations.size} successful builds in range #{build_range}"
+    puts "Average build time for #{build_durations.size} successful builds in range #{project.build_range}"
     puts ms_to_readable_duration(build_durations.inject(:+).to_f / build_durations.size)
 
     puts "\nAverage build times for steps"
@@ -144,6 +133,9 @@ def main(options)
         puts format("%s %s", ms_to_readable_duration(step[1]), step[0])
       end
   end
+rescue ArgumentError => e
+  puts e.message
+  exit(-1)
 end
 
 # Format a duration in milliseconds as an eight-character string,
@@ -163,6 +155,7 @@ def mean(array)
 end
 
 # Begin here: Parse command line options
+project = Circlarify::Project.new
 options = {
   container_num: 0,
   output_format: :human_readable
@@ -211,5 +204,5 @@ OptionParser.new do |opts|
   project.provide_cli_options opts
 end.parse!
 
-main(options)
+main(project, options)
 exit(0)

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module Circlarify
+  # Represents a single Circle build
   class Build
     # @param [CircleProject] api
     # @param [build_descriptor:Object] build_info
@@ -25,15 +28,16 @@ module Circlarify
 
     # @param [Fixnum] container The container ID #
     # @param [String] step The build step to search for (e.g. "rake install")
-    # @return [Object, nil] full build output JSON object from CircleCI, or nil if error in retrieval
-    #   Example output JSON: https://gist.github.com/bcjordan/8349fbb1edc284839b42ae53ad19b68a
+    # @return [Object, nil] full build output JSON object from CircleCI,
+    #   or nil if error in retrieval
+    # Example output JSON: https://gist.github.com/bcjordan/8349fbb1edc284839b42ae53ad19b68a
     def get_log(container, step)
       @api.get_log(build_num, container, step)
     end
 
     def outcome
       # Possible build outcomes:
-      # :canceled, :infrastructure_fail, :timedout, :failed, :no_tests or :success
+      # :canceled, :infrastructure_fail, :timedout, :failed, :no_tests, :success
       @info['outcome']
     end
 

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -1,0 +1,55 @@
+module Circlarify
+  class Build
+    # @param [build_descriptor:Object] build_info
+    def initialize(build_info)
+      @info = build_info
+    end
+
+    def build_num
+      @info['build_num']
+    end
+
+    def build_time_millis
+      @info['build_time_millis']
+    end
+
+    def branch
+      @info['branch']
+    end
+
+    def branch?(branch_name)
+      branch_name.nil? || (@info['branch'] == branch_name)
+    end
+
+    def outcome
+      # Possible build outcomes:
+      # :canceled, :infrastructure_fail, :timedout, :failed, :no_tests or :success
+      @info['outcome']
+    end
+
+    def succeeded?
+      @info['outcome'] == 'success'
+    end
+
+    def failed?
+      @info['outcome'] == 'failed' || @info['outcome'] == 'timedout'
+    end
+
+    def queued_at
+      DateTime.parse(@info['queued_at'])
+    rescue => _
+      nil
+    end
+
+    def start_time
+      Time.parse(@info['start_time'])
+    rescue => _
+      nil
+    end
+
+    def steps
+      @info['steps']
+    end
+
+  end
+end

--- a/lib/build.rb
+++ b/lib/build.rb
@@ -1,7 +1,9 @@
 module Circlarify
   class Build
+    # @param [CircleProject] api
     # @param [build_descriptor:Object] build_info
-    def initialize(build_info)
+    def initialize(api, build_info)
+      @api = api
       @info = build_info
     end
 
@@ -19,6 +21,14 @@ module Circlarify
 
     def branch?(branch_name)
       branch_name.nil? || (@info['branch'] == branch_name)
+    end
+
+    # @param [Fixnum] container The container ID #
+    # @param [String] step The build step to search for (e.g. "rake install")
+    # @return [Object, nil] full build output JSON object from CircleCI, or nil if error in retrieval
+    #   Example output JSON: https://gist.github.com/bcjordan/8349fbb1edc284839b42ae53ad19b68a
+    def get_log(container, step)
+      @api.get_log(build_num, container, step)
     end
 
     def outcome
@@ -51,5 +61,8 @@ module Circlarify
       @info['steps']
     end
 
+    def url
+      @api.build_url build_num
+    end
   end
 end

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -87,25 +87,6 @@ class CircleProject
     get_recent_builds.first['build_num']
   end
 
-  # Given a set of options, generate a reasonable range of builds to consider.
-  # Separated out to be useful to command-line tools.
-  # @param opts.start_build [Fixnum] (optional) - The first build to include in
-  #        the results.  If omitted, 30 builds will be returned.
-  # @param opts.end_build [Fixnum] (optional) - The last build to include in the
-  #        results.  If omitted, results will end with the most recent build.
-  # @return [Range] A range of build numbers matching the given options
-  def build_range_from_options(opts = {})
-    # Default end build should be the most recent build
-    end_build = opts[:end_build] || get_latest_build_num
-
-    # Default start build should give us 30 builds up to the end build.
-    # This allows us to make only one API call in the all-defaults case, since
-    # the recent builds API call returns 30 builds.
-    start_build = opts[:start_build] || end_build - 29
-
-    start_build..end_build
-  end
-
   # Retrieve the set of build descriptor objects from the CircleCI API for this
   # project for the given range
   # @param range [Enumerable<Fixnum>] set of build numbers to retrieve

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -5,6 +5,7 @@ require 'open-uri'
 require 'parallel'
 require 'zlib'
 
+GITHUB_PROJECT_WEB_BASE = 'https://circleci.com/gh'
 GITHUB_PROJECT_API_BASE = 'https://circleci.com/api/v1.1/project/github'.freeze
 CACHE_DIRECTORY = File.expand_path('~/.circlarify/builds').freeze
 
@@ -12,9 +13,14 @@ CACHE_DIRECTORY = File.expand_path('~/.circlarify/builds').freeze
 class CircleProject
   extend Memoist
 
-  def initialize(project = 'code-dot-org/code-dot-org')
-    @project = project
-    @project_api_base = "#{GITHUB_PROJECT_API_BASE}/#{@project}"
+  # @param [String] repository - repo name, like "code-dot-org/code-dot-org"
+  def initialize(repository)
+    @project_web_base = "#{GITHUB_PROJECT_WEB_BASE}/#{repository}"
+    @project_api_base = "#{GITHUB_PROJECT_API_BASE}/#{repository}"
+  end
+
+  def build_url(build_num)
+    "#{@project_web_base}/#{build_num}"
   end
 
   # @param build_num [Fixnum] The CircleCI build #

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'json'
 require 'memoist'
@@ -7,7 +9,7 @@ require 'zlib'
 require_relative './constants'
 
 GITHUB_PROJECT_WEB_BASE = 'https://circleci.com/gh'
-GITHUB_PROJECT_API_BASE = 'https://circleci.com/api/v1.1/project/github'.freeze
+GITHUB_PROJECT_API_BASE = 'https://circleci.com/api/v1.1/project/github'
 
 # Abstracted access to a Circle CI project builds via their REST API
 class CircleProject
@@ -30,60 +32,88 @@ class CircleProject
   #   Example output JSON: https://gist.github.com/bcjordan/02f7c2906b524fa86ec75b19f9a72cd2
   def get_build(build_num, ensure_full_summary = false)
     # First, check local cache
-    if File.exist? cache_file_name(build_num)
-      Zlib::GzipReader.open(cache_file_name(build_num)) do |file|
-        return JSON.parse(file.read)
-      end
-    end
+    return cached_build(build_num) if cached?(build_num)
 
     # Second, try pulling from the build summary
     unless ensure_full_summary
-      short_summary = get_recent_builds.find {|b| b['build_num'] == build_num}
+      short_summary = recent_builds.find { |b| b['build_num'] == build_num }
       return short_summary if short_summary
     end
 
     # Finally, download the whole thing
-    body = nil
+    fetch_build build_num
+  end
+
+  def fetch_build(build_num)
+    # Download the build, parse it, and save it to the local cache if the
+    # build outcome is determined
+    body = download_build_body build_num
+    build_summary = JSON.parse(body)
+    if build_summary && !build_summary['outcome'].nil?
+      save_build_to_cache build_num, body
+    end
+    build_summary
+  end
+
+  def download_build_body(build_num)
     download_attempts_remaining = 3
-    while body.nil? && download_attempts_remaining > 0
+    while download_attempts_remaining.positive?
       begin
-        body = open("#{@project_api_base}/#{build_num}").read
+        return open("#{@project_api_base}/#{build_num}").read
       rescue
         download_attempts_remaining -= 1
         sleep(0.25)
       end
     end
+  end
 
-    # Parse build and return it, saving to local cache if the build outcome is determined
-    build_summary = JSON.parse(body)
-    if build_summary && !build_summary['outcome'].nil?
-      FileUtils.mkdir_p(Circlarify::CACHE_DIRECTORY)
-      Zlib::GzipWriter.open(cache_file_name(build_num)) do |file|
-        file.write body
-      end
+  def cached?(build_num)
+    File.exist? cache_file_name(build_num)
+  end
+
+  def save_build_to_cache(build_num, body)
+    FileUtils.mkdir_p(Circlarify::CACHE_DIRECTORY)
+    Zlib::GzipWriter.open(cache_file_name(build_num)) do |file|
+      file.write body
     end
-    build_summary
+  end
+
+  def cached_build(build_num)
+    Zlib::GzipReader.open(cache_file_name(build_num)) do |file|
+      return JSON.parse(file.read)
+    end
   end
 
   # @param [Fixnum] build_num The build ID #
   # @param [Fixnum] container_num The container ID #
-  # @param [String] grep_for_step The build step to search for (e.g. "rake install")
-  # @return [Object, nil] full build output JSON object from CircleCI, or nil if error in retrieval
-  #   Example output JSON: https://gist.github.com/bcjordan/8349fbb1edc284839b42ae53ad19b68a
-  def get_log(build_num, container_num, grep_for_step)
-    JSON.parse(open(build_step_output_url(get_build(build_num, true), container_num, grep_for_step)).read)
-  rescue => _
+  # @param [String] grep_for_step The build step to search for
+  #   (e.g. "rake install")
+  # @param [Bool] verbose Whether to report errors
+  # @return [Object, nil] full build output JSON object from CircleCI,
+  #   or nil if error in retrieval
+  # Example output JSON: https://gist.github.com/bcjordan/8349fbb1edc284839b42ae53ad19b68a
+  def get_log(build_num, container_num, grep_for_step, verbose = false)
+    JSON.parse(
+      open(
+        build_step_output_url(
+          get_build(build_num, true),
+          container_num, grep_for_step
+        )
+      ).read
+    )
+  rescue => e
+    STDERR.puts e.message if verbose
   end
 
   # @return [Array<build_descriptor:Object>] 30 most recent build descriptors
   # from the CircleCI API, in reverse-chronological order.
-  def get_recent_builds
+  def recent_builds
     JSON.parse(open(@project_api_base).read)
   end
 
   # @return [Integer] The most recent build number in the project
-  def get_latest_build_num
-    get_recent_builds.first['build_num']
+  def latest_build_num
+    recent_builds.first['build_num']
   end
 
   # Retrieve the set of build descriptor objects from the CircleCI API for this
@@ -100,21 +130,25 @@ class CircleProject
       range,
       progress: "Downloading #{range.min}..#{range.max}",
       in_processes: 50
-    ) {|n| get_build(n, ensure_full_summary)}
+    ) { |n| get_build(n, ensure_full_summary) }
   end
 
   memoize :get_build
   memoize :get_log
-  memoize :get_recent_builds
+  memoize :recent_builds
 
   private
 
   # Returns the full output URL for a given build step
-  # @param [Fixnum] build_object The build information object from the Circle API
+  # @param [Fixnum] build_object The build information object from the
+  #   Circle API
   # @param [Fixnum] container_id The container ID #
-  # @param [String] grep_for_step The build step to search for (e.g. "rake install")
+  # @param [String] grep_for_step The build step to search for
+  #   (e.g. "rake install")
   def build_step_output_url(build_object, container_id, grep_for_step)
-    build_object['steps'].select { |o| o['name'].include? grep_for_step }[0]['actions'][container_id]['output_url']
+    build_object['steps'].select do |o|
+      o['name'].include? grep_for_step
+    end[0]['actions'][container_id]['output_url']
   end
 
   # @return [String] Location of cache file for build

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -8,7 +8,6 @@ require_relative './constants'
 
 GITHUB_PROJECT_WEB_BASE = 'https://circleci.com/gh'
 GITHUB_PROJECT_API_BASE = 'https://circleci.com/api/v1.1/project/github'.freeze
-CACHE_DIRECTORY = "#{Circlarify::LOCAL_FILES_PATH}/builds".freeze
 
 # Abstracted access to a Circle CI project builds via their REST API
 class CircleProject
@@ -58,7 +57,7 @@ class CircleProject
     # Parse build and return it, saving to local cache if the build outcome is determined
     build_summary = JSON.parse(body)
     if build_summary && !build_summary['outcome'].nil?
-      FileUtils.mkdir_p(CACHE_DIRECTORY)
+      FileUtils.mkdir_p(Circlarify::CACHE_DIRECTORY)
       Zlib::GzipWriter.open(cache_file_name(build_num)) do |file|
         file.write body
       end
@@ -120,6 +119,6 @@ class CircleProject
 
   # @return [String] Location of cache file for build
   def cache_file_name(build_num)
-    "#{CACHE_DIRECTORY}/#{build_num}.json.gz"
+    "#{Circlarify::CACHE_DIRECTORY}/#{build_num}.json.gz"
   end
 end

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -4,10 +4,11 @@ require 'memoist'
 require 'open-uri'
 require 'parallel'
 require 'zlib'
+require_relative './constants'
 
 GITHUB_PROJECT_WEB_BASE = 'https://circleci.com/gh'
 GITHUB_PROJECT_API_BASE = 'https://circleci.com/api/v1.1/project/github'.freeze
-CACHE_DIRECTORY = File.expand_path('~/.circlarify/builds').freeze
+CACHE_DIRECTORY = "#{Circlarify::LOCAL_FILES_PATH}/builds".freeze
 
 # Abstracted access to a Circle CI project builds via their REST API
 class CircleProject

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,46 +1,49 @@
 require 'ostruct'
 require 'yaml'
+require_relative './constants'
 
 #
 # Reads configuration defaults out of ~/.circlarify/config
 # Allows those defaults to be overriden by command-line options
 # Exposes those settings to the rest of the application
 #
-class Config
-  USER_CONFIG_FILE_NAME = 'config.yml'
-  USER_CONFIG_FILE_PATH = File.expand_path("~/.circlarify/#{USER_CONFIG_FILE_NAME}").freeze
+module Circlarify
+  class Config
+    USER_CONFIG_FILE_NAME = 'config.yml'
+    USER_CONFIG_FILE_PATH = "#{Circlarify::LOCAL_FILES_PATH}/#{USER_CONFIG_FILE_NAME}".freeze
 
-  def initialize
-    @arguments = OpenStruct.new
-  end
-
-  def repository
-    @arguments.repository || user_config.repository || raise(ArgumentError.new <<-ERR)
-No repository specified.  Pass --repository <repository name> or configure one in #{USER_CONFIG_FILE_PATH}.
-    ERR
-  end
-
-  # Mix global configuration options into the option parser, with documentation.
-  # @param [OptionParser] opts
-  def add_to_cli_options(opts)
-    opts.separator <<-BANNER
-
-  GLOBAL CONFIGURATION OPTIONS:
-    These options can all be passed on the command line, or they can be given
-    configured defaults by editing your local config file.
-    Your config file should be at #{USER_CONFIG_FILE_PATH}.
-
-    BANNER
-
-    opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
-      @arguments.repository = s
+    def initialize
+      @arguments = OpenStruct.new
     end
-  end
 
-  def user_config
-    @user_config ||= OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)
-  rescue Exception
-    # Problem loading the user config? Just act like there isn't one there.
-    @user_config = OpenStruct.new
+    def repository
+      @arguments.repository || user_config.repository || raise(ArgumentError.new <<-ERR)
+  No repository specified.  Pass --repository <repository name> or configure one in #{USER_CONFIG_FILE_PATH}.
+      ERR
+    end
+
+    # Mix global configuration options into the option parser, with documentation.
+    # @param [OptionParser] opts
+    def add_to_cli_options(opts)
+      opts.separator <<-BANNER
+  
+    GLOBAL CONFIGURATION OPTIONS:
+      These options can all be passed on the command line, or they can be given
+      configured defaults by editing your local config file.
+      Your config file should be at #{USER_CONFIG_FILE_PATH}.
+
+      BANNER
+
+      opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
+        @arguments.repository = s
+      end
+    end
+
+    def user_config
+      @user_config ||= OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)
+    rescue Exception
+      # Problem loading the user config? Just act like there isn't one there.
+      @user_config = OpenStruct.new
+    end
   end
 end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 require 'singleton'
 require 'yaml'
 require_relative './constants'
 
-#
-# Reads configuration defaults out of ~/.circlarify/config
-# Allows those defaults to be overriden by command-line options
-# Exposes those settings to the rest of the application
-#
 module Circlarify
+  #
+  # Reads configuration defaults out of ~/.circlarify/config
+  # Allows those defaults to be overriden by command-line options
+  # Exposes those settings to the rest of the application
+  #
   class Config
     include Singleton
 
     def initialize
       @user_config = OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)
-    rescue Exception
+    rescue
       # Problem loading the user config? Just act like there isn't one there.
       @user_config = OpenStruct.new
     end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -37,6 +37,11 @@ module Circlarify
       opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
         @arguments.repository = s
       end
+
+      opts.on_tail('-h', '--help', 'Show this message.') do
+        puts opts
+        exit
+      end
     end
 
     def user_config

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,0 +1,46 @@
+require 'ostruct'
+require 'yaml'
+
+#
+# Reads configuration defaults out of ~/.circlarify/config
+# Allows those defaults to be overriden by command-line options
+# Exposes those settings to the rest of the application
+#
+class Config
+  USER_CONFIG_FILE_NAME = 'config.yml'
+  USER_CONFIG_FILE_PATH = File.expand_path("~/.circlarify/#{USER_CONFIG_FILE_NAME}").freeze
+
+  def initialize
+    @arguments = OpenStruct.new
+  end
+
+  def repository
+    @arguments.repository || user_config.repository || raise(ArgumentError.new <<-ERR)
+No repository specified.  Pass --repository <repository name> or configure one in #{USER_CONFIG_FILE_PATH}.
+    ERR
+  end
+
+  # Mix global configuration options into the option parser, with documentation.
+  # @param [OptionParser] opts
+  def add_to_cli_options(opts)
+    opts.separator <<-BANNER
+
+  GLOBAL CONFIGURATION OPTIONS:
+    These options can all be passed on the command line, or they can be given
+    configured defaults by editing your local config file.
+    Your config file should be at #{USER_CONFIG_FILE_PATH}.
+
+    BANNER
+
+    opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
+      @arguments.repository = s
+    end
+  end
+
+  def user_config
+    @user_config ||= OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)
+  rescue Exception
+    # Problem loading the user config? Just act like there isn't one there.
+    @user_config = OpenStruct.new
+  end
+end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'singleton'
 require 'yaml'
 require_relative './constants'
 
@@ -8,47 +9,21 @@ require_relative './constants'
 # Exposes those settings to the rest of the application
 #
 module Circlarify
+
   class Config
+    include Singleton
     USER_CONFIG_FILE_NAME = 'config.yml'
     USER_CONFIG_FILE_PATH = "#{Circlarify::LOCAL_FILES_PATH}/#{USER_CONFIG_FILE_NAME}".freeze
 
     def initialize
-      @arguments = OpenStruct.new
-    end
-
-    def repository
-      @arguments.repository || user_config.repository || raise(ArgumentError.new <<-ERR)
-  No repository specified.  Pass --repository <repository name> or configure one in #{USER_CONFIG_FILE_PATH}.
-      ERR
-    end
-
-    # Mix global configuration options into the option parser, with documentation.
-    # @param [OptionParser] opts
-    def add_to_cli_options(opts)
-      opts.separator <<-BANNER
-  
-    GLOBAL CONFIGURATION OPTIONS:
-      These options can all be passed on the command line, or they can be given
-      configured defaults by editing your local config file.
-      Your config file should be at #{USER_CONFIG_FILE_PATH}.
-
-      BANNER
-
-      opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
-        @arguments.repository = s
-      end
-
-      opts.on_tail('-h', '--help', 'Show this message.') do
-        puts opts
-        exit
-      end
-    end
-
-    def user_config
-      @user_config ||= OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)
+      @user_config = OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)
     rescue Exception
       # Problem loading the user config? Just act like there isn't one there.
       @user_config = OpenStruct.new
+    end
+
+    def repository
+      @user_config.repository
     end
   end
 end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,8 +11,6 @@ require_relative './constants'
 module Circlarify
   class Config
     include Singleton
-    USER_CONFIG_FILE_NAME = 'config.yml'
-    USER_CONFIG_FILE_PATH = "#{Circlarify::LOCAL_FILES_PATH}/#{USER_CONFIG_FILE_NAME}".freeze
 
     def initialize
       @user_config = OpenStruct.new YAML.load_file(USER_CONFIG_FILE_PATH)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -9,7 +9,6 @@ require_relative './constants'
 # Exposes those settings to the rest of the application
 #
 module Circlarify
-
   class Config
     include Singleton
     USER_CONFIG_FILE_NAME = 'config.yml'

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,3 +1,6 @@
 module Circlarify
   LOCAL_FILES_PATH = File.expand_path('~/.circlarify').freeze
+  USER_CONFIG_FILE_NAME = 'config.yml'
+  USER_CONFIG_FILE_PATH = "#{LOCAL_FILES_PATH}/#{USER_CONFIG_FILE_NAME}".freeze
+  CACHE_DIRECTORY = "#{LOCAL_FILES_PATH}/builds".freeze
 end

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Circlarify
-  LOCAL_FILES_PATH = File.expand_path('~/.circlarify').freeze
+  LOCAL_FILES_PATH = File.expand_path('~/.circlarify')
   USER_CONFIG_FILE_NAME = 'config.yml'
-  USER_CONFIG_FILE_PATH = "#{LOCAL_FILES_PATH}/#{USER_CONFIG_FILE_NAME}".freeze
-  CACHE_DIRECTORY = "#{LOCAL_FILES_PATH}/builds".freeze
+  USER_CONFIG_FILE_PATH = "#{LOCAL_FILES_PATH}/#{USER_CONFIG_FILE_NAME}"
+  CACHE_DIRECTORY = "#{LOCAL_FILES_PATH}/builds"
 end

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,0 +1,3 @@
+module Circlarify
+  LOCAL_FILES_PATH = File.expand_path('~/.circlarify').freeze
+end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -1,5 +1,6 @@
 require 'memoist'
 require 'ostruct'
+require_relative './build'
 require_relative './circle_project'
 require_relative './config'
 
@@ -64,7 +65,7 @@ module Circlarify
     # @return [Array<build_descriptor:Object>] set of found build descriptors
     #   in given range.
     def builds(ensure_full_summary = false)
-      api.get_builds(build_range, ensure_full_summary)
+      api.get_builds(build_range, ensure_full_summary).map{|info| Build.new(info)}
     end
 
     # Mix global configuration options into the option parser, with documentation.
@@ -111,5 +112,6 @@ module Circlarify
 
     memoize :api
     memoize :build_range
+    memoize :builds
   end
 end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -28,27 +28,32 @@ module Circlarify
         if @arguments.after > @arguments.before
           raise ArgumentError.new("Invalid range #{@arguments.after}..#{@arguments.before}")
         end
-        (@arguments.after)..(@arguments.before)
+        first = @arguments.after
+        last = @arguments.before
       elsif @arguments.after && @arguments.count
-        (@arguments.after)..(@arguments.after + @arguments.count - 1)
+        first = @arguments.after
+        last = @arguments.after + @arguments.count - 1
       elsif @arguments.before && @arguments.count
-        (@arguments.before - @arguments.count + 1)..(@arguments.before)
+        first = @arguments.before - @arguments.count + 1
+        last = @arguments.before
       elsif @arguments.after
-        (@arguments.after)..(latest_build_num)
+        first = @arguments.after
+        last = api.get_latest_build_num
       elsif @arguments.before
         raise ArgumentError.new("Cannot specify --before without --after or --count.")
       elsif @arguments.count
-        last = latest_build_num
-        (last - @arguments.count + 1)..(last)
+        last = api.get_latest_build_num
+        first = last - @arguments.count + 1
       else
         # Default to 30 builds since the recent builds API call returns 30 builds.
-        last = latest_build_num
-        (last - 29)..(last)
+        last = api.get_latest_build_num
+        first = last - 29
       end
+      first..last
     end
 
-    def latest_build_num
-      CircleProject.new(repository).get_latest_build_num
+    def api
+      @api ||= CircleProject.new(repository)
     end
 
     # Mix global configuration options into the option parser, with documentation.

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -1,0 +1,45 @@
+require 'ostruct'
+require_relative './config'
+
+module Circlarify
+
+  #
+  # Represents Circle CI builds on a particular repo.
+  # Knows how to set up command line options and resolve them usefully into
+  # a subset of builds we'll work with.
+  #
+  class Project
+    def initialize
+      @arguments = OpenStruct.new
+    end
+
+    def repository
+      @arguments.repository ||
+          Config.instance.repository ||
+          raise(ArgumentError.new("No repository specified.  Pass one (--repository) or configure a default in #{Config.USER_CONFIG_FILE_PATH}."))
+    end
+
+    # Mix global configuration options into the option parser, with documentation.
+    # @param [OptionParser] opts
+    def provide_cli_options(opts)
+      opts.separator <<-BANNER
+    BUILD SELECTION
+      These options let you select which repository and which subset of builds
+      you'd like to examine.
+      Some options can be given configured defaults by setting them up in a
+      local configuration file.  Yours should be found at:
+      #{Config::USER_CONFIG_FILE_PATH}
+
+      BANNER
+
+      opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
+        @repository = s
+      end
+
+      opts.on_tail('-h', '--help', 'Show this message.') do
+        puts opts
+        exit
+      end
+    end
+  end
+end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -20,8 +20,10 @@ module Circlarify
 
     def repository
       @arguments.repository ||
-          Config.instance.repository ||
-          raise(ArgumentError.new("No repository specified.  Pass one (--repository) or configure a default in #{Config.USER_CONFIG_FILE_PATH}."))
+        Config.instance.repository ||
+        raise(ArgumentError, "No repository specified. "\
+        "Pass one (--repository) or configure a default in "\
+        "#{USER_CONFIG_FILE_PATH}.")
     end
 
     def api
@@ -72,12 +74,13 @@ module Circlarify
     # @param [OptionParser] opts
     def provide_cli_options(opts)
       opts.separator <<-BANNER
+      
     BUILD SELECTION
       These options let you select which repository and which subset of builds
       you'd like to examine.
       Some options can be given configured defaults by setting them up in a
       local configuration file.  Yours should be found at:
-      #{Config::USER_CONFIG_FILE_PATH}
+      #{USER_CONFIG_FILE_PATH}
 
       BANNER
 
@@ -97,11 +100,12 @@ module Circlarify
         @arguments.count = n
       end
 
+      opts.on('--end BuildNumber', Integer, '(deprecated) see --before') do |n|
+        @arguments.before = n
+      end
+
       opts.on('--start BuildNumber', Integer, '(deprecated) see --after') do |n|
         @arguments.after = n
-      end
-      opts.on('--end EndBuildNumber', Integer, '(deprecated) see --before') do |n|
-        @arguments.before = n
       end
 
       opts.on_tail('-h', '--help', 'Show this message.') do

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -65,7 +65,7 @@ module Circlarify
     # @return [Array<build_descriptor:Object>] set of found build descriptors
     #   in given range.
     def builds(ensure_full_summary = false)
-      api.get_builds(build_range, ensure_full_summary).map{|info| Build.new(info)}
+      api.get_builds(build_range, ensure_full_summary).map{|info| Build.new(api, info)}
     end
 
     # Mix global configuration options into the option parser, with documentation.

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'memoist'
 require 'ostruct'
 require_relative './build'
@@ -5,7 +7,6 @@ require_relative './circle_project'
 require_relative './config'
 
 module Circlarify
-
   #
   # Represents Circle CI builds on a particular repo.
   # Knows how to set up command line options and resolve them usefully into
@@ -19,11 +20,13 @@ module Circlarify
     end
 
     def repository
-      @arguments.repository ||
-        Config.instance.repository ||
-        raise(ArgumentError, "No repository specified. "\
-        "Pass one (--repository) or configure a default in "\
-        "#{USER_CONFIG_FILE_PATH}.")
+      repo = @arguments.repository || Config.instance.repository
+      unless repo
+        raise ArgumentError,
+              'No repository specified. Pass one (--repository) or configure '\
+              "a default in #{USER_CONFIG_FILE_PATH}."
+      end
+      repo
     end
 
     def api
@@ -33,10 +36,12 @@ module Circlarify
     # @return [Range] A range of build numbers matching the options passed
     def build_range
       if @arguments.after && @arguments.before && @arguments.count
-        raise ArgumentError.new("Cannot specify --after, --before AND --count: Maximum of two.")
+        raise ArgumentError,
+              'Cannot specify --after, --before AND --count: Maximum of two.'
       elsif @arguments.after && @arguments.before
         if @arguments.after > @arguments.before
-          raise ArgumentError.new("Invalid range #{@arguments.after}..#{@arguments.before}")
+          raise ArgumentError,
+                "Invalid range #{@arguments.after}..#{@arguments.before}"
         end
         first = @arguments.after
         last = @arguments.before
@@ -48,33 +53,35 @@ module Circlarify
         last = @arguments.before
       elsif @arguments.after
         first = @arguments.after
-        last = api.get_latest_build_num
+        last = api.latest_build_num
       elsif @arguments.before
-        raise ArgumentError.new("Cannot specify --before without --after or --count.")
+        raise ArgumentError,
+              'Cannot specify --before without --after or --count.'
       elsif @arguments.count
-        last = api.get_latest_build_num
+        last = api.latest_build_num
         first = last - @arguments.count + 1
       else
-        # Default to 30 builds since the recent builds API call returns 30 builds.
-        last = api.get_latest_build_num
+        # Default to 30 builds; the recent builds API call returns 30 builds.
+        last = api.latest_build_num
         first = last - 29
       end
       first..last
     end
 
     # @param ensure_full_summary [Boolean] If true, will not use build metadata
-    #        from the recent builds API, which omits certain fields (like 'steps')
+    #   from the recent builds API, which omits certain fields (like 'steps')
     # @return [Array<build_descriptor:Object>] set of found build descriptors
     #   in given range.
     def builds(ensure_full_summary = false)
-      api.get_builds(build_range, ensure_full_summary).map{|info| Build.new(api, info)}
+      api.get_builds(build_range, ensure_full_summary)
+         .map { |info| Build.new(api, info) }
     end
 
-    # Mix global configuration options into the option parser, with documentation.
+    # Mix global configuration options into the option parser.
     # @param [OptionParser] opts
     def provide_cli_options(opts)
       opts.separator <<-BANNER
-      
+
     BUILD SELECTION
       These options let you select which repository and which subset of builds
       you'd like to examine.
@@ -84,31 +91,38 @@ module Circlarify
 
       BANNER
 
-      opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
+      opts.on('-r', '--repository RepositoryName', String,
+              'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
         @arguments.repository = s
       end
 
-      opts.on('-a', '--after BuildNumber', Integer, 'First build to include in build range.') do |n|
+      opts.on('-a', '--after BuildNumber', Integer,
+              'First build to include in build range.') do |n|
         @arguments.after = n
       end
 
-      opts.on('-b', '--before BuildNumber', Integer, 'Last build to include in build range.') do |n|
+      opts.on('-b', '--before BuildNumber', Integer,
+              'Last build to include in build range.') do |n|
         @arguments.before = n
       end
 
-      opts.on('-c', '--count BuildCount', Integer, 'How many builds to include in build range.') do |n|
+      opts.on('-c', '--count BuildCount', Integer,
+              'How many builds to include in build range.') do |n|
         @arguments.count = n
       end
 
-      opts.on('--end BuildNumber', Integer, '(deprecated) see --before') do |n|
+      opts.on('--end BuildNumber', Integer,
+              '(deprecated) see --before') do |n|
         @arguments.before = n
       end
 
-      opts.on('--start BuildNumber', Integer, '(deprecated) see --after') do |n|
+      opts.on('--start BuildNumber', Integer,
+              '(deprecated) see --after') do |n|
         @arguments.after = n
       end
 
-      opts.on_tail('-h', '--help', 'Show this message.') do
+      opts.on_tail('-h', '--help',
+                   'Show this message.') do
         puts opts
         exit
       end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require_relative './circle_project'
 require_relative './config'
 
 module Circlarify
@@ -19,6 +20,37 @@ module Circlarify
           raise(ArgumentError.new("No repository specified.  Pass one (--repository) or configure a default in #{Config.USER_CONFIG_FILE_PATH}."))
     end
 
+    # @return [Range] A range of build numbers matching the options passed
+    def build_range
+      if @arguments.after && @arguments.before && @arguments.count
+        raise ArgumentError.new("Cannot specify --after, --before AND --count: Maximum of two.")
+      elsif @arguments.after && @arguments.before
+        if @arguments.after > @arguments.before
+          raise ArgumentError.new("Invalid range #{@arguments.after}..#{@arguments.before}")
+        end
+        (@arguments.after)..(@arguments.before)
+      elsif @arguments.after && @arguments.count
+        (@arguments.after)..(@arguments.after + @arguments.count - 1)
+      elsif @arguments.before && @arguments.count
+        (@arguments.before - @arguments.count + 1)..(@arguments.before)
+      elsif @arguments.after
+        (@arguments.after)..(latest_build_num)
+      elsif @arguments.before
+        raise ArgumentError.new("Cannot specify --before without --after or --count.")
+      elsif @arguments.count
+        last = latest_build_num
+        (last - @arguments.count + 1)..(last)
+      else
+        # Default to 30 builds since the recent builds API call returns 30 builds.
+        last = latest_build_num
+        (last - 29)..(last)
+      end
+    end
+
+    def latest_build_num
+      CircleProject.new(repository).get_latest_build_num
+    end
+
     # Mix global configuration options into the option parser, with documentation.
     # @param [OptionParser] opts
     def provide_cli_options(opts)
@@ -33,7 +65,26 @@ module Circlarify
       BANNER
 
       opts.on('-r', '--repository RepositoryName', String, 'Which repository to use (e.g. code-dot-org/code-dot-org)') do |s|
-        @repository = s
+        @arguments.repository = s
+      end
+
+      opts.on('-a', '--after BuildNumber', Integer, 'First build to include in build range.') do |n|
+        @arguments.after = n
+      end
+
+      opts.on('-b', '--before BuildNumber', Integer, 'Last build to include in build range.') do |n|
+        @arguments.before = n
+      end
+
+      opts.on('-c', '--count BuildCount', Integer, 'How many builds to include in build range.') do |n|
+        @arguments.count = n
+      end
+
+      opts.on('--start BuildNumber', Integer, '(deprecated) see --after') do |n|
+        @arguments.after = n
+      end
+      opts.on('--end EndBuildNumber', Integer, '(deprecated) see --before') do |n|
+        @arguments.before = n
       end
 
       opts.on_tail('-h', '--help', 'Show this message.') do

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -61,7 +61,6 @@ end.parse!
 
 begin
   @project = CircleProject.new(project.repository)
-  build_range = project.build_range
 rescue ArgumentError => e
   puts e.message
   exit(-1)
@@ -82,20 +81,20 @@ def describe_fail_type(f)
 end
 
 fail_types_list = fail_types_to_check.map { |f| describe_fail_type(f) }.join "\n"
-puts "Checking builds #{build_range} for output:\n#{fail_types_list}"
+puts "Checking builds #{project.build_range} for output:\n#{fail_types_list}"
 puts "Limited to branch: #{options[:branch_name]}" unless options[:branch_name].nil?
 
-Parallel.each(build_range, in_processes: MAX_THREADS) do |build|
+Parallel.each(project.builds, in_processes: MAX_THREADS) do |build|
   fail_types_to_check.each do |known_fail|
     # Skip this build if it's not on the requested branch
-    next unless options[:branch_name].nil? || (@project.get_build(build)['branch'] == options[:branch_name])
+    next unless build.branch? options[:branch_name]
 
-    output = @project.get_log(build, known_fail[:container], known_fail[:step_string])
+    output = @project.get_log(build.build_num, known_fail[:container], known_fail[:step_string])
 
     begin
       full_output_string = output[0]['message']
       if full_output_string.include? known_fail[:search_string]
-        build_url = @project.build_url(build)
+        build_url = @project.build_url(build.build_num)
         if options[:count]
           count = full_output_string.split("\n").count do |line|
             line.include? known_fail[:search_string]

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -61,10 +61,6 @@ OptionParser.new do |opts|
   opts.on('--branch BranchName', String, 'Limit results to builds for one branch.') do |branch_name|
     options[:branch_name] = branch_name
   end
-  opts.on_tail('-h', '--help', 'Show this message.') do
-    puts opts
-    exit
-  end
 
   config.add_to_cli_options opts
 end.parse!

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -5,7 +5,6 @@
 require 'optparse'
 require 'parallel'
 require_relative './lib/project'
-require_relative './lib/circle_project'
 
 RUN_UI_TESTS_STEP_STRING = 'run_tests'
 RUN_UI_TESTS_CONTAINER = 1
@@ -59,13 +58,6 @@ OptionParser.new do |opts|
   project.provide_cli_options opts
 end.parse!
 
-begin
-  @project = CircleProject.new(project.repository)
-rescue ArgumentError => e
-  puts e.message
-  exit(-1)
-end
-
 fail_types_to_check = KNOWN_FAIL_TYPES
 
 if options[:grep_string]
@@ -80,40 +72,44 @@ def describe_fail_type(f)
   "#{f[:search_string]} in container #{f[:container]} step #{f[:step_string]}"
 end
 
-fail_types_list = fail_types_to_check.map { |f| describe_fail_type(f) }.join "\n"
-puts "Checking builds #{project.build_range} for output:\n#{fail_types_list}"
-puts "Limited to branch: #{options[:branch_name]}" unless options[:branch_name].nil?
+begin
+  fail_types_list = fail_types_to_check.map { |f| describe_fail_type(f) }.join "\n"
+  puts "Checking builds #{project.build_range} for output:\n#{fail_types_list}"
+  puts "Limited to branch: #{options[:branch_name]}" unless options[:branch_name].nil?
 
-Parallel.each(project.builds, in_processes: MAX_THREADS) do |build|
-  fail_types_to_check.each do |known_fail|
-    # Skip this build if it's not on the requested branch
-    next unless build.branch? options[:branch_name]
+  Parallel.each(project.builds, in_processes: MAX_THREADS) do |build|
+    fail_types_to_check.each do |known_fail|
+      # Skip this build if it's not on the requested branch
+      next unless build.branch? options[:branch_name]
 
-    output = @project.get_log(build.build_num, known_fail[:container], known_fail[:step_string])
+      output = build.get_log(known_fail[:container], known_fail[:step_string])
 
-    begin
-      full_output_string = output[0]['message']
-      if full_output_string.include? known_fail[:search_string]
-        build_url = @project.build_url(build.build_num)
-        if options[:count]
-          count = full_output_string.split("\n").count do |line|
-            line.include? known_fail[:search_string]
+      begin
+        full_output_string = output[0]['message']
+        if full_output_string.include? known_fail[:search_string]
+          if options[:count]
+            count = full_output_string.split("\n").count do |line|
+              line.include? known_fail[:search_string]
+            end
+            puts "Build #{build.url} output contains #{count} of: #{known_fail[:search_string]}"
+          elsif options[:whole_lines]
+            lines = []
+            full_output_string.split("\n").each do |line|
+              lines << line if line.include? known_fail[:search_string]
+            end
+            puts "Build #{build.url} output contains lines:"
+            lines.each{|l| puts l}
+          else
+            puts "Build #{build.url} output contains: #{known_fail[:search_string]}"
           end
-          puts "Build #{build_url} output contains #{count} of: #{known_fail[:search_string]}"
-        elsif options[:whole_lines]
-          lines = []
-          full_output_string.split("\n").each do |line|
-            lines << line if line.include? known_fail[:search_string]
-          end
-          puts "Build #{build_url} output contains lines:"
-          lines.each{|l| puts l}
-        else
-          puts "Build #{build_url} output contains: #{known_fail[:search_string]}"
         end
+      rescue => _
       end
-    rescue => _
     end
   end
+rescue ArgumentError => e
+  puts e.message
+  exit(-1)
 end
 
 exit(0)

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -29,7 +29,7 @@ KNOWN_FAIL_TYPES = [
   },
 ]
 
-config = Config.new
+config = Circlarify::Config.new
 
 options = {}
 OptionParser.new do |opts|

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -4,6 +4,7 @@
 
 require 'optparse'
 require 'parallel'
+require_relative './lib/config'
 require_relative './lib/circle_project'
 
 RUN_UI_TESTS_STEP_STRING = 'run_tests'
@@ -27,6 +28,8 @@ KNOWN_FAIL_TYPES = [
     container: RUN_UI_TESTS_CONTAINER
   },
 ]
+
+config = Config.new
 
 options = {}
 OptionParser.new do |opts|
@@ -62,9 +65,11 @@ OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  config.add_to_cli_options opts
 end.parse!
 
-@project = CircleProject.new('code-dot-org/code-dot-org')
+@project = CircleProject.new(config.repository)
 build_range = @project.build_range_from_options(options)
 
 fail_types_to_check = KNOWN_FAIL_TYPES
@@ -95,20 +100,21 @@ Parallel.each(build_range, in_processes: MAX_THREADS) do |build|
     begin
       full_output_string = output[0]['message']
       if full_output_string.include? known_fail[:search_string]
+        build_url = @project.build_url(build)
         if options[:count]
           count = full_output_string.split("\n").count do |line|
             line.include? known_fail[:search_string]
           end
-          puts "Build https://circleci.com/gh/code-dot-org/code-dot-org/#{build} output contains #{count} of: #{known_fail[:search_string]}"
+          puts "Build #{build_url} output contains #{count} of: #{known_fail[:search_string]}"
         elsif options[:whole_lines]
           lines = []
           full_output_string.split("\n").each do |line|
             lines << line if line.include? known_fail[:search_string]
           end
-          puts "Build https://circleci.com/gh/code-dot-org/code-dot-org/#{build} output contains lines:"
+          puts "Build #{build_url} output contains lines:"
           lines.each{|l| puts l}
         else
-          puts "Build https://circleci.com/gh/code-dot-org/code-dot-org/#{build} output contains: #{known_fail[:search_string]}"
+          puts "Build #{build_url} output contains: #{known_fail[:search_string]}"
         end
       end
     rescue => _

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -6,7 +6,7 @@ require 'optparse'
 require 'parallel'
 require_relative './lib/project'
 
-RUN_UI_TESTS_STEP_STRING = 'run_tests'
+RUN_UI_TESTS_STEP_STRING = 'run_tests'.freeze
 RUN_UI_TESTS_CONTAINER = 1
 MAX_THREADS = 50
 
@@ -25,8 +25,8 @@ KNOWN_FAIL_TYPES = [
     search_string: 'invalid base64',
     step_string: RUN_UI_TESTS_STEP_STRING,
     container: RUN_UI_TESTS_CONTAINER
-  },
-]
+  }
+].freeze
 
 project = Circlarify::Project.new
 
@@ -34,24 +34,36 @@ options = {}
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./search-circle-builds [options]'
 
-  opts.on('--grep "String to Search for"', String, 'Search for given string.') do |grep_string|
+  opts.on('--grep "String to Search for"',
+          String,
+          'Search for given string.') do |grep_string|
     options[:grep_string] = grep_string
   end
-  opts.on('--whole-lines', TrueClass, 'Print entire lines of found strings in output.') do |is_true|
+  opts.on('--whole-lines',
+          TrueClass,
+          'Print entire lines of found strings in output.') do |is_true|
     options[:whole_lines] = is_true
   end
-  opts.on('--count', TrueClass, 'Counts number of found strings in output.') do |is_true|
+  opts.on('--count',
+          TrueClass,
+          'Counts number of found strings in output.') do |is_true|
     options[:count] = is_true
   end
-  opts.on('--grep-container ', String, 'Search given container # for grep string.') do |grep_container|
+  opts.on('--grep-container ',
+          String,
+          'Search given container # for grep string.') do |grep_container|
     options[:grep_container] = grep_container.to_i
   end
   options[:grep_container] ||= RUN_UI_TESTS_CONTAINER
-  opts.on('--grep-step ', String, 'Search given step (substring) for grep string.') do |grep_step|
+  opts.on('--grep-step ',
+          String,
+          'Search given step (substring) for grep string.') do |grep_step|
     options[:grep_step] = grep_step
   end
   options[:grep_step] ||= RUN_UI_TESTS_STEP_STRING
-  opts.on('--branch BranchName', String, 'Limit results to builds for one branch.') do |branch_name|
+  opts.on('--branch BranchName',
+          String,
+          'Limit results to builds for one branch.') do |branch_name|
     options[:branch_name] = branch_name
   end
 
@@ -73,9 +85,10 @@ def describe_fail_type(f)
 end
 
 begin
-  fail_types_list = fail_types_to_check.map { |f| describe_fail_type(f) }.join "\n"
+  fail_types_list = fail_types_to_check.map { |f| describe_fail_type(f) }
+                                       .join "\n"
   puts "Checking builds #{project.build_range} for output:\n#{fail_types_list}"
-  puts "Limited to branch: #{options[:branch_name]}" unless options[:branch_name].nil?
+  puts "Limited to branch: #{options[:branch_name]}" if options[:branch_name]
 
   Parallel.each(project.builds, in_processes: MAX_THREADS) do |build|
     fail_types_to_check.each do |known_fail|
@@ -83,6 +96,7 @@ begin
       next unless build.branch? options[:branch_name]
 
       output = build.get_log(known_fail[:container], known_fail[:step_string])
+      next if output.nil?
 
       begin
         full_output_string = output[0]['message']
@@ -91,19 +105,22 @@ begin
             count = full_output_string.split("\n").count do |line|
               line.include? known_fail[:search_string]
             end
-            puts "Build #{build.url} output contains #{count} of: #{known_fail[:search_string]}"
+            puts "Build #{build.url} output contains #{count} of: "\
+              "#{known_fail[:search_string]}"
           elsif options[:whole_lines]
             lines = []
             full_output_string.split("\n").each do |line|
               lines << line if line.include? known_fail[:search_string]
             end
             puts "Build #{build.url} output contains lines:"
-            lines.each{|l| puts l}
+            lines.each { |l| puts l }
           else
-            puts "Build #{build.url} output contains: #{known_fail[:search_string]}"
+            puts "Build #{build.url} output contains:"\
+              "#{known_fail[:search_string]}"
           end
         end
-      rescue => _
+      rescue => e
+        STDERR.puts e
       end
     end
   end

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -67,11 +67,11 @@ end.parse!
 
 begin
   @project = CircleProject.new(project.repository)
+  build_range = project.build_range
 rescue ArgumentError => e
   puts e.message
   exit(-1)
 end
-build_range = @project.build_range_from_options(options)
 
 fail_types_to_check = KNOWN_FAIL_TYPES
 

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -4,7 +4,7 @@
 
 require 'optparse'
 require 'parallel'
-require_relative './lib/config'
+require_relative './lib/project'
 require_relative './lib/circle_project'
 
 RUN_UI_TESTS_STEP_STRING = 'run_tests'
@@ -29,7 +29,7 @@ KNOWN_FAIL_TYPES = [
   },
 ]
 
-config = Circlarify::Config.new
+project = Circlarify::Project.new
 
 options = {}
 OptionParser.new do |opts|
@@ -62,11 +62,11 @@ OptionParser.new do |opts|
     options[:branch_name] = branch_name
   end
 
-  config.add_to_cli_options opts
+  project.provide_cli_options opts
 end.parse!
 
 begin
-  @project = CircleProject.new(config.repository)
+  @project = CircleProject.new(project.repository)
 rescue ArgumentError => e
   puts e.message
   exit(-1)

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -35,12 +35,6 @@ options = {}
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./search-circle-builds [options]'
 
-  opts.on('--start StartBuildNumber', String, 'Start searching at build #.') do |n|
-    options[:start_build] = n.to_i
-  end
-  opts.on('--end EndBuildNumber', String, 'End searching at build #.') do |n|
-    options[:end_build] = n.to_i
-  end
   opts.on('--grep "String to Search for"', String, 'Search for given string.') do |grep_string|
     options[:grep_string] = grep_string
   end

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -65,7 +65,12 @@ OptionParser.new do |opts|
   config.add_to_cli_options opts
 end.parse!
 
-@project = CircleProject.new(config.repository)
+begin
+  @project = CircleProject.new(config.repository)
+rescue ArgumentError => e
+  puts e.message
+  exit(-1)
+end
 build_range = @project.build_range_from_options(options)
 
 fail_types_to_check = KNOWN_FAIL_TYPES

--- a/test-flakiness
+++ b/test-flakiness
@@ -42,7 +42,12 @@ OptionParser.new do |opts|
   config.add_to_cli_options opts
 end.parse!
 
-@project = CircleProject.new(config.repository)
+begin
+  @project = CircleProject.new(config.repository)
+rescue ArgumentError => e
+  puts e.message
+  exit(-1)
+end
 build_range = @project.build_range_from_options(options)
 
 puts [

--- a/test-flakiness
+++ b/test-flakiness
@@ -22,12 +22,6 @@ options = OpenStruct.new
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./test-flakiness [options]'
 
-  opts.on('--start StartBuildNumber', String, 'Start searching at build #.') do |n|
-    options[:start_build] = n.to_i
-  end
-  opts.on('--end EndBuildNumber', String, 'End searching at build #.') do |n|
-    options[:end_build] = n.to_i
-  end
   opts.on('--branch BranchName', String, 'Limit results to builds for one branch.') do |branch_name|
     options[:branch_name] = branch_name
   end

--- a/test-flakiness
+++ b/test-flakiness
@@ -39,11 +39,6 @@ OptionParser.new do |opts|
     options.group_by = t
   end
 
-  opts.on_tail('-h', '--help', 'Show this message.') do
-    puts opts
-    exit
-  end
-
   config.add_to_cli_options opts
 end.parse!
 

--- a/test-flakiness
+++ b/test-flakiness
@@ -44,11 +44,11 @@ end.parse!
 
 begin
   @project = CircleProject.new(project.repository)
+  build_range = project.build_range
 rescue ArgumentError => e
   puts e.message
   exit(-1)
 end
-build_range = @project.build_range_from_options(options)
 
 puts [
   "Computing flakiness rates",

--- a/test-flakiness
+++ b/test-flakiness
@@ -6,7 +6,7 @@ require 'optparse'
 require 'ostruct'
 require 'parallel'
 require 'ruby-progressbar'
-require_relative './lib/config'
+require_relative './lib/project'
 require_relative './lib/circle_project'
 require 'pp'
 
@@ -16,7 +16,7 @@ MAX_THREADS = 50
 CONTAINER = 1
 STEP_NAME = 'run_tests'
 
-config = Circlarify::Config.new
+project = Circlarify::Project.new
 
 options = OpenStruct.new
 OptionParser.new do |opts|
@@ -39,11 +39,11 @@ OptionParser.new do |opts|
     options.group_by = t
   end
 
-  config.add_to_cli_options opts
+  project.add_to_cli_options opts
 end.parse!
 
 begin
-  @project = CircleProject.new(config.repository)
+  @project = CircleProject.new(project.repository)
 rescue ArgumentError => e
   puts e.message
   exit(-1)

--- a/test-flakiness
+++ b/test-flakiness
@@ -9,11 +9,11 @@ require 'ruby-progressbar'
 require_relative './lib/project'
 require 'pp'
 
-Groupdate.time_zone = "Pacific Time (US & Canada)"
+Groupdate.time_zone = 'Pacific Time (US & Canada)'
 
 MAX_THREADS = 50
 CONTAINER = 1
-STEP_NAME = 'run_tests'
+STEP_NAME = 'run_tests'.freeze
 
 project = Circlarify::Project.new
 
@@ -21,14 +21,28 @@ options = OpenStruct.new
 OptionParser.new do |opts|
   opts.banner = 'Usage: ./test-flakiness [options]'
 
-  opts.on('--branch BranchName', String, 'Limit results to builds for one branch.') do |branch_name|
+  opts.on(
+    '--branch BranchName',
+    String,
+    'Limit results to builds for one branch.'
+  ) do |branch_name|
     options[:branch_name] = branch_name
   end
-  opts.on('--test "Test name filter"', String, "Regular expression for filtering results to a certain test.") do |test_name_filter|
+
+  opts.on(
+    '--test "Test name filter"',
+    String,
+    'Regular expression for filtering results to a certain test.'
+  ) do |test_name_filter|
     options[:test_name_filter] = Regexp.new test_name_filter, Regexp::IGNORECASE
   end
+
   # Optional argument with keyword completion.
-  opts.on("--group-by Period", [:day, :week, :month], "Select grouping period (day, week, month).") do |t|
+  opts.on(
+    '--group-by Period',
+    [:day, :week, :month],
+    'Select grouping period (day, week, month).'
+  ) do |t|
     options.group_by = t
   end
 
@@ -36,33 +50,37 @@ OptionParser.new do |opts|
 end.parse!
 
 begin
+  filter = options.test_name_filter
   puts [
-    "Computing flakiness rates",
-    options.test_name_filter ? "for test #{options.test_name_filter.source}" : nil,
+    'Computing flakiness rates',
+    filter ? "for test #{filter.source}" : nil,
     options.branch_name ? "on branch #{options.branch_name}" : nil,
     "in builds #{project.build_range}",
     options.group_by ? "grouped by #{options.group_by}" : nil,
-    "(1.0 = 100% failures)"
-  ].reject{|x| x.nil?}.join(' ')
+    '(1.0 = 100% failures)'
+  ].compact.join(' ')
 
-  puts "Scanning logs..."
+  puts 'Scanning logs...'
   download_progress_bar = ProgressBar.create(total: project.build_range.size)
 
   test_stats_rollup = {}
   # For now, limit this tool to searching for UI test failures
-  Parallel.each(project.builds, in_processes: MAX_THREADS, finish: lambda do |_, _, result|
-    download_progress_bar.increment
-    # This block runs in the main thread every time we complete a parallel block
-    next unless result.is_a? Hash
-    result.each do |test_name, stats|
-      test_stats_rollup[test_name] ||= {
-        started: [],
-        failed: []
-      }
-      test_stats_rollup[test_name][:started].concat(stats[:started])
-      test_stats_rollup[test_name][:failed].concat(stats[:failed])
+  Parallel.each(
+    project.builds,
+    in_processes: MAX_THREADS,
+    finish: lambda do |_, _, result|
+      download_progress_bar.increment
+      # This block runs in the main thread each time a parallel block returns
+      next unless result.is_a? Hash
+      result.each do |test_name, stats|
+        test_stats_rollup[test_name] ||= {
+          started: [],
+          failed: []
+        }
+        test_stats_rollup[test_name][:started].concat(stats[:started])
+        test_stats_rollup[test_name][:failed].concat(stats[:failed])
+      end
     end
-  end
   ) do |build|
     # Skip this build if it's not on the requested branch
     next unless build.branch? options[:branch_name]
@@ -73,31 +91,32 @@ begin
       full_output_string = output[0]['message']
 
       # Find every time a test we care about was started
-      test_starts = full_output_string.
-          scan(/cucumber.*--out (\w+)_output\.html/).
-          map{|matches| matches[0]}.
-          select{|name| options[:test_name_filter].nil? ? true : name =~ options[:test_name_filter]}
+      test_starts = full_output_string
+                    .scan(/cucumber.*--out (\w+)_output\.html/)
+                    .map { |matches| matches[0] }
+                    .select do |name|
+                      options[:test_name_filter].nil? ||
+                        name =~ options[:test_name_filter]
+                    end
 
       # Build a metadata map of tests
-      tests = test_starts.reduce({}) do |sums, name|
-        sums[name] ||= {started: [], failed: []}
+      tests = test_starts.each_with_object({}) do |name, sums|
+        sums[name] ||= { started: [], failed: [] }
         sums[name][:started].push(build_date)
-        sums
       end
 
       # Find all failures, and add them to our test data
-      full_output_string.scan(/UI tests failed with <b>(\w+)<\/b>/).
-          map{|matches| matches[0]}.
-          each do |name|
-            if tests[name]
-              tests[name][:failed].push(build_date)
-            end
-          end
+      full_output_string
+        .scan(/UI tests failed with <b>(\w+)<.b>/)
+        .map { |matches| matches[0] }
+        .each do |name|
+          tests[name][:failed].push(build_date) if tests[name]
+        end
 
       # 3. Report back to main thread:
-      # pp tests
       tests
-    rescue => _
+    rescue => e
+      STDERR.puts e.message if options.verbose
     end
   end
   download_progress_bar.finish
@@ -110,18 +129,20 @@ def flakiness_for_whole_sample(test_stats)
   start_count = test_stats[:started].size
   failure_count = test_stats[:failed].size
   {
-      flakiness: failure_count.to_f / start_count,
-      sample_size: start_count
+    flakiness: failure_count.to_f / start_count,
+    sample_size: start_count
   }
 end
 
 def flakiness_by_period(test_stats, period)
-  starts_by_period = test_stats[:started].send("group_by_#{period}") {|x| x}
-  failures_by_period = test_stats[:failed].send("group_by_#{period}") {|x| x}
+  starts_by_period = test_stats[:started].send("group_by_#{period}") { |x| x }
+  failures_by_period = test_stats[:failed].send("group_by_#{period}") { |x| x }
   stats_by_period = starts_by_period.map do |k, v|
-    start_count = v.size
-    failure_count = failures_by_period[k] ? failures_by_period[k].size : 0
-    [k, {flakiness: failure_count.to_f / start_count, sample_size: start_count}]
+    failure_count = failures_by_period[k].try(:size) || 0
+    [k, {
+      flakiness: failure_count.to_f / v.size,
+      sample_size: v.size
+    }]
   end
   Hash[stats_by_period]
 end
@@ -132,12 +153,14 @@ if options.group_by
     pp flakiness_by_period(stats, options.group_by)
   end
 else
-  test_stats_ordered = test_stats_rollup.
-      map{|k, v| [k, flakiness_for_whole_sample(v)]}.
-      sort {|a, b| b[1][:flakiness] <=> a[1][:flakiness]}
-  puts "Flake    n Test Name"
+  test_stats_ordered = test_stats_rollup
+                       .map { |k, v| [k, flakiness_for_whole_sample(v)] }
+                       .sort { |a, b| b[1][:flakiness] <=> a[1][:flakiness] }
+  puts 'Flake    n Test Name'
   test_stats_ordered.each do |row|
-    puts format("%1.3f %4d %s", row[1][:flakiness], row[1][:sample_size], row[0])
+    puts format('%1.3f %4d %s',
+                row[1][:flakiness],
+                row[1][:sample_size],
+                row[0])
   end
 end
-

--- a/test-flakiness
+++ b/test-flakiness
@@ -6,6 +6,7 @@ require 'optparse'
 require 'ostruct'
 require 'parallel'
 require 'ruby-progressbar'
+require_relative './lib/config'
 require_relative './lib/circle_project'
 require 'pp'
 
@@ -14,6 +15,8 @@ Groupdate.time_zone = "Pacific Time (US & Canada)"
 MAX_THREADS = 50
 CONTAINER = 1
 STEP_NAME = 'run_tests'
+
+config = Config.new
 
 options = OpenStruct.new
 OptionParser.new do |opts|
@@ -40,9 +43,11 @@ OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  config.add_to_cli_options opts
 end.parse!
 
-@project = CircleProject.new('code-dot-org/code-dot-org')
+@project = CircleProject.new(config.repository)
 build_range = @project.build_range_from_options(options)
 
 puts [

--- a/test-flakiness
+++ b/test-flakiness
@@ -16,7 +16,7 @@ MAX_THREADS = 50
 CONTAINER = 1
 STEP_NAME = 'run_tests'
 
-config = Config.new
+config = Circlarify::Config.new
 
 options = OpenStruct.new
 OptionParser.new do |opts|

--- a/test-flakiness
+++ b/test-flakiness
@@ -7,7 +7,6 @@ require 'ostruct'
 require 'parallel'
 require 'ruby-progressbar'
 require_relative './lib/project'
-require_relative './lib/circle_project'
 require 'pp'
 
 Groupdate.time_zone = "Pacific Time (US & Canada)"
@@ -33,84 +32,79 @@ OptionParser.new do |opts|
     options.group_by = t
   end
 
-  project.add_to_cli_options opts
+  project.provide_cli_options opts
 end.parse!
 
 begin
-  @project = CircleProject.new(project.repository)
-  build_range = project.build_range
+  puts [
+    "Computing flakiness rates",
+    options.test_name_filter ? "for test #{options.test_name_filter.source}" : nil,
+    options.branch_name ? "on branch #{options.branch_name}" : nil,
+    "in builds #{project.build_range}",
+    options.group_by ? "grouped by #{options.group_by}" : nil,
+    "(1.0 = 100% failures)"
+  ].reject{|x| x.nil?}.join(' ')
+
+  puts "Scanning logs..."
+  download_progress_bar = ProgressBar.create(total: project.build_range.size)
+
+  test_stats_rollup = {}
+  # For now, limit this tool to searching for UI test failures
+  Parallel.each(project.builds, in_processes: MAX_THREADS, finish: lambda do |_, _, result|
+    download_progress_bar.increment
+    # This block runs in the main thread every time we complete a parallel block
+    next unless result.is_a? Hash
+    result.each do |test_name, stats|
+      test_stats_rollup[test_name] ||= {
+        started: [],
+        failed: []
+      }
+      test_stats_rollup[test_name][:started].concat(stats[:started])
+      test_stats_rollup[test_name][:failed].concat(stats[:failed])
+    end
+  end
+  ) do |build|
+    # Skip this build if it's not on the requested branch
+    next unless build.branch? options[:branch_name]
+
+    begin
+      build_date = Date.parse(build.start_time.to_s) # Ugh - clean up
+      output = build.get_log(CONTAINER, STEP_NAME)
+      full_output_string = output[0]['message']
+
+      # Find every time a test we care about was started
+      test_starts = full_output_string.
+          scan(/cucumber.*--out (\w+)_output\.html/).
+          map{|matches| matches[0]}.
+          select{|name| options[:test_name_filter].nil? ? true : name =~ options[:test_name_filter]}
+
+      # Build a metadata map of tests
+      tests = test_starts.reduce({}) do |sums, name|
+        sums[name] ||= {started: [], failed: []}
+        sums[name][:started].push(build_date)
+        sums
+      end
+
+      # Find all failures, and add them to our test data
+      full_output_string.scan(/UI tests failed with <b>(\w+)<\/b>/).
+          map{|matches| matches[0]}.
+          each do |name|
+            if tests[name]
+              tests[name][:failed].push(build_date)
+            end
+          end
+
+      # 3. Report back to main thread:
+      # pp tests
+      tests
+    rescue => _
+    end
+  end
+  download_progress_bar.finish
 rescue ArgumentError => e
   puts e.message
   exit(-1)
 end
-
-puts [
-  "Computing flakiness rates",
-  options.test_name_filter ? "for test #{options.test_name_filter.source}" : nil,
-  options.branch_name ? "on branch #{options.branch_name}" : nil,
-  "in builds #{build_range}",
-  options.group_by ? "grouped by #{options.group_by}" : nil,
-  "(1.0 = 100% failures)"
-].reject{|x| x.nil?}.join(' ')
-
-puts "Scanning logs..."
-download_progress_bar = ProgressBar.create(total: build_range.size)
-
-test_stats_rollup = {}
-# For now, limit this tool to searching for UI test failures
-Parallel.each(build_range, in_processes: MAX_THREADS, finish: lambda do |_, _, result|
-  download_progress_bar.increment
-  # This block runs in the main thread every time we complete a parallel block
-  next unless result.is_a? Hash
-  result.each do |test_name, stats|
-    test_stats_rollup[test_name] ||= {
-      started: [],
-      failed: []
-    }
-    test_stats_rollup[test_name][:started].concat(stats[:started])
-    test_stats_rollup[test_name][:failed].concat(stats[:failed])
-  end
-end
-) do |build|
-  build_info = @project.get_build(build)
-
-  # Skip this build if it's not on the requested branch
-  next unless options[:branch_name].nil? || (build_info['branch'] == options[:branch_name])
-
-  begin
-    build_date = Date.parse(build_info['start_time'])
-    output = @project.get_log(build, CONTAINER, STEP_NAME)
-    full_output_string = output[0]['message']
-
-    # Find every time a test we care about was started
-    test_starts = full_output_string.
-        scan(/cucumber.*--out (\w+)_output\.html/).
-        map{|matches| matches[0]}.
-        select{|name| options[:test_name_filter].nil? ? true : name =~ options[:test_name_filter]}
-
-    # Build a metadata map of tests
-    tests = test_starts.reduce({}) do |sums, name|
-      sums[name] ||= {started: [], failed: []}
-      sums[name][:started].push(build_date)
-      sums
-    end
-
-    # Find all failures, and add them to our test data
-    full_output_string.scan(/UI tests failed with <b>(\w+)<\/b>/).
-        map{|matches| matches[0]}.
-        each do |name|
-          if tests[name]
-            tests[name][:failed].push(build_date)
-          end
-        end
-
-    # 3. Report back to main thread:
-    # pp tests
-    tests
-  rescue => _
-  end
-end
-download_progress_bar.finish
 
 def flakiness_for_whole_sample(test_stats)
   start_count = test_stats[:started].size


### PR DESCRIPTION
Okay, okay, this PR is _waaay_ too big, but we're still in the early, wild days of this project so I don't feel too bad.  There are a few major improvements here:

1. Centralize provision of build range selection and build retrieval.

   We add several new classes in the `Circlarify` module, with the primary end of deduplicating command-line option handling and the side benefit of giving the scripts a much nicer interface into builds.  This introduces a lot of code, but should reduce duplication overall.

2. New build range options!

   All tools now accept the following build range flags, in the style of `grep`:
   * `-a`/`--after {num}` to set the beginning of the build range.
   * `-b`/`--before {num}` to set the end of the build range.
   * `-c`/`--count {num}` to set the size of the build range.
   Obviously some combinations of these arguments won't work, and we display useful errors in those cases, but this makes certain queries very simple, like failure rates for the last 500 builds: `./compute-failure-rates -c 500`.  The `--start` and `--end` flags are still available as aliases for `--after` and `--before`.

3. Linting

   I've enabled Hound (with Rubocop) and, besides disabling some of the code complexity metrics, the project now passes linting.