### PR TITLE
Changes I had sitting around

### DIFF
--- a/lib/build.rb
+++ b/lib/build.rb
@@ -28,11 +28,12 @@ module Circlarify
 
     # @param [Fixnum] container The container ID #
     # @param [String] step The build step to search for (e.g. "rake install")
+    # @param [Bool] verbose
     # @return [Object, nil] full build output JSON object from CircleCI,
     #   or nil if error in retrieval
     # Example output JSON: https://gist.github.com/bcjordan/8349fbb1edc284839b42ae53ad19b68a
-    def get_log(container, step)
-      @api.get_log(build_num, container, step)
+    def get_log(container, step, verbose = false)
+      @api.get_log(build_num, container, step, verbose)
     end
 
     def outcome

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -149,7 +149,7 @@ class CircleProject
   #   (e.g. "rake install")
   def build_step_output_url(build_object, container_id, grep_for_step)
     step = build_object['steps']
-      .select { |o| o['name'].include? grep_for_step }
+           .select { |o| o['name'].include? grep_for_step }
     step[0]['actions'][container_id]['output_url']
   end
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -21,6 +21,10 @@ module Circlarify
       @user_config = OpenStruct.new
     end
 
+    def api_token
+      @user_config.api_token
+    end
+
     def repository
       @user_config.repository
     end

--- a/test-flakiness
+++ b/test-flakiness
@@ -46,6 +46,10 @@ OptionParser.new do |opts|
     options.group_by = t
   end
 
+  opts.on('--verbose') do
+    options.verbose = true
+  end
+
   project.provide_cli_options opts
 end.parse!
 
@@ -61,7 +65,7 @@ begin
   ].compact.join(' ')
 
   puts 'Scanning logs...'
-  download_progress_bar = ProgressBar.create(total: project.build_range.size)
+  download_progress_bar = ProgressBar.create(total: project.build_range.size) unless options.verbose
 
   test_stats_rollup = {}
   # For now, limit this tool to searching for UI test failures
@@ -69,7 +73,7 @@ begin
     project.builds,
     in_processes: MAX_THREADS,
     finish: lambda do |_, _, result|
-      download_progress_bar.increment
+      download_progress_bar.increment if download_progress_bar
       # This block runs in the main thread each time a parallel block returns
       next unless result.is_a? Hash
       result.each do |test_name, stats|
@@ -87,7 +91,8 @@ begin
 
     begin
       build_date = Date.parse(build.start_time.to_s) # Ugh - clean up
-      output = build.get_log(CONTAINER, STEP_NAME)
+      puts "#{build.build_num} #{build_date}" if options.verbose
+      output = build.get_log(CONTAINER, STEP_NAME, options.verbose)
       full_output_string = output[0]['message']
 
       # Find every time a test we care about was started
@@ -119,7 +124,7 @@ begin
       STDERR.puts e.message if options.verbose
     end
   end
-  download_progress_bar.finish
+  download_progress_bar.finish if download_progress_bar
 rescue ArgumentError => e
   puts e.message
   exit(-1)


### PR DESCRIPTION
Some work I did while investigating why some build logs weren't downloading / I was getting incorrect test flakiness stats.

* Adds a `--verbose` flag to test-flakiness tool that will write to the console if there's an error retrieving a log.  This is how I tracked down that we were hitting expired S3 log URLs.
* Lets the user specify a Circle API token in their config file.  I originally thought the log errors were an authorization problem, so I added this - it ended up not helping with the expired S3 links, but may be useful down the road if we ever want to do anything requiring write access.