### PR TITLE
Use strings instead of dates with google charts

### DIFF
--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -159,8 +159,7 @@ elsif options[:output_format] == :plot
   js_data = "[\n"
   js_data += "['Date', 'Failures', 'Successes'],\n"
   ordered_stats.each do |stats|
-    # Represent date as a JS date, constructed with ms since the epoch
-    js_build_time = "new Date(#{stats[:date].to_f * 1000})"
+    js_build_time = stats[:date].strftime('"%b %d"')
     js_failures = stats[:failed_builds]
     js_successes = stats[:total_builds] - stats[:failed_builds]
 
@@ -190,7 +189,7 @@ elsif options[:output_format] == :plot
 
         var options = {
           title: '#{title}',
-          hAxis: {title: 'Build date',  titleTextStyle: {color: '#333'}},
+          hAxis: {title: 'Build date',  titleTextStyle: {color: '#333'}, showTextEvery: 2},
           colors: ['#C40000', '#7FB900'],
           isStacked: true
         };


### PR DESCRIPTION
Dates can only be used with continuous major axes in Google charts, but we're really treating each day's data as a discrete data point. This specifies the dates as a bunch of strings ("Apr 3", "Apr 4", etc.) so that Google will treat our data the same way.

This fixes the "zero-width first bar" problem, but also means I have to be more exact about which build I'm starting with when I generate the plot. I plan to add options to specify the build range by date instead of build number to make that easier.