### PR TITLE
Make test-flakiness search container 0

### DIFF
--- a/test-flakiness
+++ b/test-flakiness
@@ -12,8 +12,8 @@ require 'pp'
 Groupdate.time_zone = 'Pacific Time (US & Canada)'
 
 MAX_THREADS = 50
-CONTAINER = 1
-STEP_NAME = 'run_tests'.freeze
+CONTAINER = 0
+STEP_NAME = 'run_ui_tests'.freeze
 
 project = Circlarify::Project.new
 


### PR DESCRIPTION
Last week we brought our project back to using one container per circle build, so UI tests now run on container 0 after the unit tests.  Therefore this tool needs to search container 0 for the `rake circle:run_ui_tests` step in particular.