### PR TITLE
Cache build results from builds that weren't run

### DIFF
--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -51,7 +51,8 @@ class CircleProject
     body = download_build_body build_num
     return nil unless body
     build_summary = JSON.parse(body)
-    if build_summary && %w(finished not_run).include?(build_summary['lifecycle'])
+    if build_summary &&
+       %w[finished not_run].include?(build_summary['lifecycle'])
       save_build_to_cache build_num, body
     end
     build_summary

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -49,8 +49,9 @@ class CircleProject
     # Download the build, parse it, and save it to the local cache if the
     # build outcome is determined
     body = download_build_body build_num
+    return nil unless body
     build_summary = JSON.parse(body)
-    if build_summary && !build_summary['outcome'].nil?
+    if build_summary && %w(finished not_run).include?(build_summary['lifecycle'])
       save_build_to_cache build_num, body
     end
     build_summary


### PR DESCRIPTION
We're only running builds for commits that have associated PRs. Circle still allocates a build number when you push commits without corresponding PRs, but just marks them as "not_run".

The other possible values for the `lifecycle` field are listed here: https://circleci.com/docs/api/v1-reference/#build. I'm not entirely sure what `not_running` indicates, but I suspect it's possible for such a build to start running later, so I'm not caching those.