### PR TITLE
Add '-s' and '-e' options for start/end dates

### DIFF
--- a/compute-failure-rates
+++ b/compute-failure-rates
@@ -169,7 +169,7 @@ elsif options[:output_format] == :plot
 
   title = "Circle CI #{options[:branch]} builds by outcome for "\
     "#{dates.min.strftime('%Y-%m-%d')}..#{dates.max.strftime('%Y-%m-%d')} "\
-    "(builds #{project.build_range})"
+    "(builds #{project.restricted_build_range})"
 
   # Write out plot
   # https://developers.google.com/chart/interactive/docs/gallery/areachart

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -117,11 +117,7 @@ class CircleProject
   # @return [Array<build_descriptor:Object>] 30 most recent build descriptors
   # from the CircleCI API, in reverse-chronological order.
   def recent_builds
-    begin
-      JSON.parse(open(with_token(@project_api_base)).read)
-    rescue
-      []
-    end
+    JSON.parse(open(with_token(@project_api_base)).read)
   end
 
   # @return [Integer] The most recent build number in the project

--- a/lib/circle_project.rb
+++ b/lib/circle_project.rb
@@ -20,6 +20,8 @@ class CircleProject
   def initialize(repository)
     @project_web_base = "#{GITHUB_PROJECT_WEB_BASE}/#{repository}"
     @project_api_base = "#{GITHUB_PROJECT_API_BASE}/#{repository}"
+    @cached_gets = 0
+    @total_gets = 0
   end
 
   def build_url(build_num)
@@ -32,8 +34,11 @@ class CircleProject
   # @return [Object] build descriptor object from the CircleCI API
   #   Example output JSON: https://gist.github.com/bcjordan/02f7c2906b524fa86ec75b19f9a72cd2
   def get_build(build_num, ensure_full_summary = false)
+    @total_gets += 1
+    cached = cached?(build_num)
+    @cached_gets += 1 if cached
     # First, check local cache
-    return cached_build(build_num) if cached?(build_num)
+    return cached_build(build_num) if cached
 
     # Second, try pulling from the build summary
     unless ensure_full_summary
@@ -112,7 +117,11 @@ class CircleProject
   # @return [Array<build_descriptor:Object>] 30 most recent build descriptors
   # from the CircleCI API, in reverse-chronological order.
   def recent_builds
-    JSON.parse(open(with_token(@project_api_base)).read)
+    begin
+      JSON.parse(open(with_token(@project_api_base)).read)
+    rescue
+      []
+    end
   end
 
   # @return [Integer] The most recent build number in the project
@@ -130,11 +139,13 @@ class CircleProject
     raise ArgumentError unless range.is_a?(Enumerable)
 
     # Download the build information we need in parallel
-    Parallel.map(
+    builds = Parallel.map(
       range,
       progress: "Downloading #{range.min}..#{range.max}",
-      in_processes: Circlarify::Config.instance.parallelism
+      in_threads: Circlarify::Config.instance.parallelism
     ) { |n| get_build(n, ensure_full_summary) }
+    puts "#{@cached_gets} of #{@total_gets} cached"
+    builds
   end
 
   memoize :get_build

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -76,12 +76,18 @@ module Circlarify
     #   in given range.
     def builds(ensure_full_summary = false)
       ret = api.get_builds(build_range, ensure_full_summary)
-         .map { |info| Build.new(api, info) }
+               .map { |info| Build.new(api, info) }
       earliest = nil
       ret = ret.select do |build|
-        next false if @arguments.after_date && build.queued_at && build.queued_at < @arguments.after_date
-        next false if @arguments.before_date && build.queued_at && build.queued_at > @arguments.before_date
-        earliest = build if build.queued_at && (earliest.nil? || build.build_num < earliest.build_num)
+        next false if @arguments.after_date &&
+                      build.queued_at &&
+                      build.queued_at < @arguments.after_date
+        next false if @arguments.before_date &&
+                      build.queued_at &&
+                      build.queued_at > @arguments.before_date
+        earliest = build if build.queued_at &&
+                            (earliest.nil? ||
+                             build.build_num < earliest.build_num)
         true
       end
       @earliest = earliest.build_num
@@ -118,7 +124,7 @@ module Circlarify
       end
 
       opts.on('-s', '--after-date date', String,
-              'Only include builds after date. Must still be within the range' +
+              'Only include builds after date. Must still be within the range'\
               'specififed by --before and --after.') do |d|
         @arguments.after_date = DateTime.parse(d)
       end
@@ -129,7 +135,7 @@ module Circlarify
       end
 
       opts.on('-e', '--before-date date', String,
-              'Only include builds before date. Must still be within the range' +
+              'Only include builds before date. Must still be within the range'\
               'specififed by --before and --after.') do |d|
         @arguments.before_date = DateTime.parse(d)
       end

--- a/search-circle-builds
+++ b/search-circle-builds
@@ -7,8 +7,8 @@ require 'parallel'
 require_relative './lib/config'
 require_relative './lib/project'
 
-RUN_UI_TESTS_STEP_STRING = 'run_tests'.freeze
-RUN_UI_TESTS_CONTAINER = 1
+RUN_UI_TESTS_STEP_STRING = 'run_ui_tests'.freeze
+RUN_UI_TESTS_CONTAINER = 0
 
 KNOWN_FAIL_TYPES = [
   {

--- a/test-flakiness
+++ b/test-flakiness
@@ -13,7 +13,7 @@ require 'pp'
 Groupdate.time_zone = 'Pacific Time (US & Canada)'
 
 CONTAINER = 0
-STEP_NAME = 'run_ui_tests'.freeze
+STEP_NAME = 'run ui tests'.freeze
 
 project = Circlarify::Project.new
 


### PR DESCRIPTION
E.g. `./compute-timing-stats -a 48373 -s 25/9/2017 --branch staging` will only include results for builds that started on or after September 25th. Unfortunately you still have to provide a starting build number that happened earlier than your start date, I never got around to automatically finding the first build on that date.